### PR TITLE
Changed from IntField to DelayedIntField

### DIFF
--- a/Assets/Tilemap/Tiles/Random Tile/Scripts/RandomTile.cs
+++ b/Assets/Tilemap/Tiles/Random Tile/Scripts/RandomTile.cs
@@ -55,7 +55,7 @@ namespace UnityEngine.Tilemaps
 		public override void OnInspectorGUI()
 		{
 			EditorGUI.BeginChangeCheck();
-			int count = EditorGUILayout.IntField("Number of Sprites", tile.m_Sprites != null ? tile.m_Sprites.Length : 0);
+			int count = EditorGUILayout.DelayedIntField("Number of Sprites", tile.m_Sprites != null ? tile.m_Sprites.Length : 0);
 			if (count < 0)
 				count = 0;
 			if (tile.m_Sprites == null || tile.m_Sprites.Length != count)

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
@@ -275,7 +275,7 @@ namespace UnityEditor
 			{
 				GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Size");
 				EditorGUI.BeginChangeCheck();
-				int newLength = EditorGUI.IntField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), tilingRule.m_Sprites.Length);
+				int newLength = EditorGUI.DelayedIntField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), tilingRule.m_Sprites.Length);
 				if (EditorGUI.EndChangeCheck())
 					Array.Resize(ref tilingRule.m_Sprites, Math.Max(newLength, 1));
 				y += k_SingleLineHeight;


### PR DESCRIPTION
The editor was clearing my sprites when changing the array size from 9 to 10 so i changed the field type to DelayedIntField.

Thanks,
Ethan