### PR TITLE
Allow toggling of state in reverse direction

### DIFF
--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
@@ -184,7 +184,10 @@ namespace UnityEditor
 						}
 						if (Event.current.type == EventType.MouseDown && r.Contains(Event.current.mousePosition))
 						{
-							tilingRule.m_Neighbors[index] = (RuleTile.TilingRule.Neighbor) (((int)tilingRule.m_Neighbors[index] + 1) % 3);
+                            				int change = 1;
+						    	if (Event.current.button == 1)
+								change = -1;
+							tilingRule.m_Neighbors[index] = (RuleTile.TilingRule.Neighbor) (((int)tilingRule.m_Neighbors[index] + change + 3) % 3);
 							GUI.changed = true;
 							Event.current.Use();
 						}


### PR DESCRIPTION
Currently if you want to set state to X, you need to click twice with left mouse button. I propose toggling in reverse direction. With this change you can click once with right mouse button to set state to X and click second time to set it to ✓. Toggling in normal direction with left mouse button will still work, of course.