### PR TITLE
Customizable RuleTile #2

### DIFF
--- a/Assets/Tilemap/Tiles/Rule Override Tile.meta
+++ b/Assets/Tilemap/Tiles/Rule Override Tile.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbcacf945e7001e4396ca2ca8573ae6c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts.meta
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e5614e4b96700843ba104987c4f190e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor.meta
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1263d004036ee7f42aeed98348b5e8cf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
@@ -1,101 +1,340 @@
 ﻿using UnityEngine;
+using UnityEngine.Tilemaps;
 using UnityEditor;
 using UnityEditorInternal;
+using System;
 using System.Collections.Generic;
 
 namespace UnityEditor
 {
 
 	[CustomEditor(typeof(RuleOverrideTile))]
-	internal class RuleOverrideTileEditor : Editor
+	internal class RuleOverrideTileEditor : RuleTileEditor
 	{
 
+		public RuleOverrideTile overrideTile { get { return (target as RuleOverrideTile); } }
+
 		private List<KeyValuePair<Sprite, Sprite>> m_Sprites;
+		private List<KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRule>> m_Rules;
 
 		ReorderableList m_SpriteList;
+		ReorderableList m_RuleList;
 
-		void OnEnable()
+		new void OnEnable()
 		{
-			RuleOverrideTile ruleOverrideTile = target as RuleOverrideTile;
-
-
 			if (m_Sprites == null)
 				m_Sprites = new List<KeyValuePair<Sprite, Sprite>>();
 
+			if (m_Rules == null)
+				m_Rules = new List<KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRule>>();
+
 			if (m_SpriteList == null)
 			{
-				ruleOverrideTile.GetOverrides(m_Sprites);
+				overrideTile.GetOverrides(m_Sprites);
 
 				m_SpriteList = new ReorderableList(m_Sprites, typeof(KeyValuePair<Sprite, Sprite>), false, true, false, false);
 				m_SpriteList.drawElementCallback = DrawSpriteElement;
 				m_SpriteList.drawHeaderCallback = DrawSpriteHeader;
-				m_SpriteList.onSelectCallback = SelectSprite;
-				m_SpriteList.elementHeight = 64;
+				m_SpriteList.elementHeight = k_DefaultElementHeight + k_PaddingBetweenRules;
 			}
-		}
+			if (m_RuleList == null)
+			{
+				overrideTile.GetOverrides(m_Rules);
 
-		void OnDisable()
-		{
-			RuleOverrideTile ruleOverrideTile = target as RuleOverrideTile;
+				m_RuleList = new ReorderableList(m_Rules, typeof(KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRule>), false, true, false, false);
+				m_RuleList.drawElementCallback = DrawRuleElement;
+				m_RuleList.drawHeaderCallback = DrawRuleHeader;
+				m_RuleList.elementHeightCallback = GetRuleElementHeight;
+			}
 		}
 
 		public override void OnInspectorGUI()
 		{
 			serializedObject.UpdateIfRequiredOrScript();
 
-			RuleOverrideTile ruleOverrideTile = target as RuleOverrideTile;
-			RuleTile ruleTile = ruleOverrideTile.m_Tile;
+			EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Tile"));
+			EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Advanced"));
+			serializedObject.ApplyModifiedProperties();
 
-			ruleOverrideTile.m_Tile = EditorGUILayout.ObjectField("Tile", ruleTile, typeof(RuleTile), false) as RuleTile;
-
-			using (new EditorGUI.DisabledScope(ruleTile == null))
+			if (!overrideTile.m_Advanced)
 			{
-				EditorGUI.BeginChangeCheck();
-				ruleOverrideTile.GetOverrides(m_Sprites);
-
-				m_SpriteList.list = m_Sprites;
-				m_SpriteList.DoLayoutList();
-				if (EditorGUI.EndChangeCheck())
+				using (new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
 				{
-					for (int i = 0; i < targets.Length; i++)
+					EditorGUI.BeginChangeCheck();
+					overrideTile.GetOverrides(m_Sprites);
+
+					m_SpriteList.list = m_Sprites;
+					m_SpriteList.DoLayoutList();
+					if (EditorGUI.EndChangeCheck())
 					{
-						RuleOverrideTile tile = targets[i] as RuleOverrideTile;
-						tile.ApplyOverrides(m_Sprites);
+						for (int i = 0; i < targets.Length; i++)
+						{
+							RuleOverrideTile tile = targets[i] as RuleOverrideTile;
+							tile.ApplyOverrides(m_Sprites);
+						}
 					}
 				}
 			}
+			else
+			{
+				using (new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
+				{
+					overrideTile.GetOverrides(m_Rules);
+
+					m_RuleList.list = m_Rules;
+					m_RuleList.DoLayoutList();
+				}
+			}
 		}
+
 		private void DrawSpriteElement(Rect rect, int index, bool selected, bool focused)
 		{
 			Sprite originalSprite = m_Sprites[index].Key;
 			Sprite overrideSprite = m_Sprites[index].Value;
 
+			rect.y += 2;
+			rect.height -= k_PaddingBetweenRules;
+
 			rect.xMax = rect.xMax / 2.0f;
-			GUI.enabled = false;
-			EditorGUI.ObjectField(rect, originalSprite.name, originalSprite, typeof(Sprite), false);
-			GUI.enabled = true;
+			using (new EditorGUI.DisabledScope(true))
+				EditorGUI.ObjectField(new Rect(rect.xMin, rect.yMin, rect.height, rect.height), originalSprite, typeof(Sprite), false);
 			rect.xMin = rect.xMax;
 			rect.xMax *= 2.0f;
 
 			EditorGUI.BeginChangeCheck();
-			overrideSprite = EditorGUI.ObjectField(rect, overrideSprite ? overrideSprite.name : "", overrideSprite, typeof(Sprite), false) as Sprite;
+			overrideSprite = EditorGUI.ObjectField(new Rect(rect.xMin, rect.yMin, rect.height, rect.height), overrideSprite, typeof(Sprite), false) as Sprite;
 			if (EditorGUI.EndChangeCheck())
+			{
 				m_Sprites[index] = new KeyValuePair<Sprite, Sprite>(originalSprite, overrideSprite);
+				SaveTile();
+			}
 		}
-
 		private void DrawSpriteHeader(Rect rect)
 		{
+			float xMax = rect.xMax;
 			rect.xMax = rect.xMax / 2.0f;
 			GUI.Label(rect, "Original", EditorStyles.label);
 			rect.xMin = rect.xMax;
-			rect.xMax *= 2.0f;
+			rect.xMax = xMax;
 			GUI.Label(rect, "Override", EditorStyles.label);
 		}
 
-		private void SelectSprite(ReorderableList list)
+		private void DrawRuleElement(Rect rect, int index, bool selected, bool focused)
 		{
-			if (0 <= list.index && list.index < m_Sprites.Count)
-				EditorGUIUtility.PingObject(m_Sprites[list.index].Key);
+			overrideTile.Override();
+
+			RuleTile.TilingRule originalRule = m_Rules[index].Key;
+			RuleTile.TilingRule overrideRule = m_Rules[index].Value;
+
+			float matrixWidth = k_DefaultElementHeight;
+
+			float xMax = rect.xMax;
+			rect.xMax = rect.xMax / 2.0f + matrixWidth - 10f;
+
+			if (index != overrideTile.m_Tile.m_TilingRules.Count)
+				DrawOriginalRuleElement(rect, originalRule);
+			else
+				DrawOriginalRuleElement(rect, originalRule, true);
+
+			rect.xMin = rect.xMax;
+			rect.xMax = xMax;
+
+			EditorGUI.BeginChangeCheck();
+			if (index != overrideTile.m_Tile.m_TilingRules.Count)
+				DrawOverrideElement(rect, originalRule);
+			else
+				DrawOverrideDefaultElement(rect, overrideRule);
+			if (EditorGUI.EndChangeCheck())
+				SaveTile();
+		}
+		public void DrawOriginalRuleElement(Rect rect, RuleTile.TilingRule originalRule, bool isDefault = false)
+		{
+			using (new EditorGUI.DisabledScope(true))
+			{
+				float yPos = rect.yMin + 2f;
+				float height = rect.height - k_PaddingBetweenRules;
+				float matrixWidth = k_DefaultElementHeight;
+
+				Rect inspectorRect = new Rect(rect.xMin, yPos, rect.width - matrixWidth * 2f - 20f, height);
+				Rect matrixRect = new Rect(rect.xMax - matrixWidth * 2f - 10f, yPos, matrixWidth, k_DefaultElementHeight);
+				Rect spriteRect = new Rect(rect.xMax - matrixWidth - 5f, yPos, matrixWidth, k_DefaultElementHeight);
+
+				if (!isDefault)
+					RuleInspectorOnGUI(inspectorRect, originalRule);
+				else
+					RuleOriginalDefaultInspectorOnGUI(inspectorRect, originalRule);
+				RuleMatrixOnGUI(matrixRect, originalRule);
+				SpriteOnGUI(spriteRect, originalRule);
+			}
+		}
+		private void DrawOverrideElement(Rect rect, RuleTile.TilingRule originalRule)
+		{
+			float yPos = rect.yMin + 2f;
+			float height = rect.height - k_PaddingBetweenRules;
+			float matrixWidth = k_DefaultElementHeight;
+
+			Rect inspectorRect = new Rect(rect.xMin, yPos, rect.width - matrixWidth - 10f, height);
+			Rect spriteRect = new Rect(rect.xMax - matrixWidth - 5f, yPos, matrixWidth, k_DefaultElementHeight);
+
+			RuleOverrideInspectorOnGUI(inspectorRect, originalRule);
+			RuleTile.TilingRule overrideRule = overrideTile[originalRule];
+			if (overrideRule != null)
+				SpriteOnGUI(spriteRect, overrideRule);
+		}
+		private void RuleOriginalDefaultInspectorOnGUI(Rect rect, RuleTile.TilingRule originalRule)
+		{
+			float y = rect.yMin;
+
+			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Rule");
+			EditorGUI.LabelField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), "Default");
+			y += k_SingleLineHeight;
+
+			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Collider");
+			EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), originalRule.m_ColliderType);
+			y += k_SingleLineHeight;
+		}
+		private void RuleOverrideInspectorOnGUI(Rect rect, RuleTile.TilingRule originalRule)
+		{
+			RuleTile.TilingRule overrideRule = overrideTile[originalRule];
+
+			float y = rect.yMin;
+			EditorGUI.BeginChangeCheck();
+
+			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Enabled");
+			bool enabled = EditorGUI.Toggle(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule != null);
+			y += k_SingleLineHeight;
+
+			if (EditorGUI.EndChangeCheck())
+			{
+				if (enabled)
+					overrideTile[originalRule] = originalRule;
+				else
+					overrideTile[originalRule] = null;
+				overrideRule = overrideTile[originalRule];
+			}
+
+			if (overrideRule == null)
+				return;
+
+			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Collider");
+			overrideRule.m_ColliderType = (Tile.ColliderType)EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_ColliderType);
+			y += k_SingleLineHeight;
+			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Output");
+			overrideRule.m_Output = (RuleTile.TilingRule.OutputSprite)EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_Output);
+			y += k_SingleLineHeight;
+
+			if (overrideRule.m_Output == RuleTile.TilingRule.OutputSprite.Animation)
+			{
+				GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Speed");
+				overrideRule.m_AnimationSpeed = EditorGUI.FloatField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_AnimationSpeed);
+				y += k_SingleLineHeight;
+			}
+			if (overrideRule.m_Output == RuleTile.TilingRule.OutputSprite.Random)
+			{
+				GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Noise");
+				overrideRule.m_PerlinScale = EditorGUI.Slider(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_PerlinScale, 0.001f, 0.999f);
+				y += k_SingleLineHeight;
+
+				GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Shuffle");
+				overrideRule.m_RandomTransform = (RuleTile.TilingRule.Transform)EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_RandomTransform);
+				y += k_SingleLineHeight;
+			}
+
+			if (overrideRule.m_Output != RuleTile.TilingRule.OutputSprite.Single)
+			{
+				GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Size");
+				EditorGUI.BeginChangeCheck();
+				int newLength = EditorGUI.DelayedIntField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_Sprites.Length);
+				if (EditorGUI.EndChangeCheck())
+					Array.Resize(ref overrideRule.m_Sprites, Math.Max(newLength, 1));
+				y += k_SingleLineHeight;
+
+				for (int i = 0; i < overrideRule.m_Sprites.Length; i++)
+				{
+					overrideRule.m_Sprites[i] = EditorGUI.ObjectField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_Sprites[i], typeof(Sprite), false) as Sprite;
+					y += k_SingleLineHeight;
+				}
+			}
+		}
+		private void DrawOverrideDefaultElement(Rect rect, RuleTile.TilingRule originalRule)
+		{
+			float yPos = rect.yMin + 2f;
+			float height = rect.height - k_PaddingBetweenRules;
+			float matrixWidth = k_DefaultElementHeight;
+
+			Rect inspectorRect = new Rect(rect.xMin, yPos, rect.width - matrixWidth - 10f, height);
+			Rect spriteRect = new Rect(rect.xMax - matrixWidth - 5f, yPos, matrixWidth, k_DefaultElementHeight);
+
+			RuleOverrideDefaultInspectorOnGUI(inspectorRect, originalRule);
+			if (overrideTile.m_OverrideDefault.m_Enabled)
+				SpriteOnGUI(spriteRect, overrideTile.m_OverrideDefault.m_TilingRule);
+		}
+		private void RuleOverrideDefaultInspectorOnGUI(Rect rect, RuleTile.TilingRule overrideRule)
+		{
+			float y = rect.yMin;
+			EditorGUI.BeginChangeCheck();
+
+			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Enabled");
+			bool enabled = EditorGUI.Toggle(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideTile.m_OverrideDefault.m_Enabled);
+			y += k_SingleLineHeight;
+
+			if (EditorGUI.EndChangeCheck())
+			{
+				overrideTile.m_OverrideDefault.m_Enabled = enabled;
+				overrideTile.m_OverrideDefault.m_TilingRule = overrideTile.m_OriginalDefault;
+			}
+
+			if (!enabled)
+				return;
+
+			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Collider");
+			overrideRule.m_ColliderType = (Tile.ColliderType)EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), overrideRule.m_ColliderType);
+			y += k_SingleLineHeight;
+		}
+		private void DrawRuleHeader(Rect rect)
+		{
+			float matrixWidth = k_DefaultElementHeight;
+
+			float xMax = rect.xMax;
+			rect.xMax = rect.xMax / 2.0f + matrixWidth - 10f;
+			GUI.Label(rect, "Original", EditorStyles.label);
+			rect.xMin = rect.xMax;
+			rect.xMax = xMax;
+			GUI.Label(rect, "Override", EditorStyles.label);
+		}
+		private float GetRuleElementHeight(int index)
+		{
+			if (index != overrideTile.m_Tile.m_TilingRules.Count)
+			{
+				var overrideRule = overrideTile[overrideTile.m_Tile.m_TilingRules[index]];
+				float overrideHeight = GetRuleElementHeight(overrideRule);
+				float originalHeight = GetRuleElementHeight(overrideTile.m_Tile.m_TilingRules[index]);
+				return Mathf.Max(overrideHeight, originalHeight);
+			}
+			else
+			{
+				var overrideRule = overrideTile.m_OverrideDefault.m_Enabled ? overrideTile.m_OverrideDefault.m_TilingRule : null;
+				float overrideHeight = GetRuleElementHeight(overrideRule);
+				float originalHeight = GetRuleElementHeight(new RuleTile.TilingRule());
+				return Mathf.Max(overrideHeight, originalHeight);
+			}
+		}
+		private float GetRuleElementHeight(RuleTile.TilingRule rule)
+		{
+			float height = k_DefaultElementHeight + k_PaddingBetweenRules;
+			if (rule != null)
+			{
+				switch (rule.m_Output)
+				{
+					case RuleTile.TilingRule.OutputSprite.Random:
+						height = k_DefaultElementHeight + k_SingleLineHeight * (rule.m_Sprites.Length + 3) + k_PaddingBetweenRules;
+						break;
+					case RuleTile.TilingRule.OutputSprite.Animation:
+						height = k_DefaultElementHeight + k_SingleLineHeight * (rule.m_Sprites.Length + 2) + k_PaddingBetweenRules;
+						break;
+				}
+			}
+			return height;
 		}
 	}
 }

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
@@ -1,0 +1,101 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditorInternal;
+using System.Collections.Generic;
+
+namespace UnityEditor
+{
+
+	[CustomEditor(typeof(RuleOverrideTile))]
+	internal class RuleOverrideTileEditor : Editor
+	{
+
+		private List<KeyValuePair<Sprite, Sprite>> m_Sprites;
+
+		ReorderableList m_SpriteList;
+
+		void OnEnable()
+		{
+			RuleOverrideTile ruleOverrideTile = target as RuleOverrideTile;
+
+
+			if (m_Sprites == null)
+				m_Sprites = new List<KeyValuePair<Sprite, Sprite>>();
+
+			if (m_SpriteList == null)
+			{
+				ruleOverrideTile.GetOverrides(m_Sprites);
+
+				m_SpriteList = new ReorderableList(m_Sprites, typeof(KeyValuePair<Sprite, Sprite>), false, true, false, false);
+				m_SpriteList.drawElementCallback = DrawSpriteElement;
+				m_SpriteList.drawHeaderCallback = DrawSpriteHeader;
+				m_SpriteList.onSelectCallback = SelectSprite;
+				m_SpriteList.elementHeight = 64;
+			}
+		}
+
+		void OnDisable()
+		{
+			RuleOverrideTile ruleOverrideTile = target as RuleOverrideTile;
+		}
+
+		public override void OnInspectorGUI()
+		{
+			serializedObject.UpdateIfRequiredOrScript();
+
+			RuleOverrideTile ruleOverrideTile = target as RuleOverrideTile;
+			RuleTile ruleTile = ruleOverrideTile.m_Tile;
+
+			ruleOverrideTile.m_Tile = EditorGUILayout.ObjectField("Tile", ruleTile, typeof(RuleTile), false) as RuleTile;
+
+			using (new EditorGUI.DisabledScope(ruleTile == null))
+			{
+				EditorGUI.BeginChangeCheck();
+				ruleOverrideTile.GetOverrides(m_Sprites);
+
+				m_SpriteList.list = m_Sprites;
+				m_SpriteList.DoLayoutList();
+				if (EditorGUI.EndChangeCheck())
+				{
+					for (int i = 0; i < targets.Length; i++)
+					{
+						RuleOverrideTile tile = targets[i] as RuleOverrideTile;
+						tile.ApplyOverrides(m_Sprites);
+					}
+				}
+			}
+		}
+		private void DrawSpriteElement(Rect rect, int index, bool selected, bool focused)
+		{
+			Sprite originalSprite = m_Sprites[index].Key;
+			Sprite overrideSprite = m_Sprites[index].Value;
+
+			rect.xMax = rect.xMax / 2.0f;
+			GUI.enabled = false;
+			EditorGUI.ObjectField(rect, originalSprite.name, originalSprite, typeof(Sprite), false);
+			GUI.enabled = true;
+			rect.xMin = rect.xMax;
+			rect.xMax *= 2.0f;
+
+			EditorGUI.BeginChangeCheck();
+			overrideSprite = EditorGUI.ObjectField(rect, overrideSprite ? overrideSprite.name : "", overrideSprite, typeof(Sprite), false) as Sprite;
+			if (EditorGUI.EndChangeCheck())
+				m_Sprites[index] = new KeyValuePair<Sprite, Sprite>(originalSprite, overrideSprite);
+		}
+
+		private void DrawSpriteHeader(Rect rect)
+		{
+			rect.xMax = rect.xMax / 2.0f;
+			GUI.Label(rect, "Original", EditorStyles.label);
+			rect.xMin = rect.xMax;
+			rect.xMax *= 2.0f;
+			GUI.Label(rect, "Override", EditorStyles.label);
+		}
+
+		private void SelectSprite(ReorderableList list)
+		{
+			if (0 <= list.index && list.index < m_Sprites.Count)
+				EditorGUIUtility.PingObject(m_Sprites[list.index].Key);
+		}
+	}
+}

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
@@ -7,9 +7,8 @@ using System.Collections.Generic;
 
 namespace UnityEditor
 {
-
 	[CustomEditor(typeof(RuleOverrideTile))]
-	internal class RuleOverrideTileEditor : RuleTileEditor
+	internal class RuleOverrideTileEditor : Editor
 	{
 
 		public RuleOverrideTile overrideTile { get { return (target as RuleOverrideTile); } }
@@ -20,7 +19,12 @@ namespace UnityEditor
 		ReorderableList m_SpriteList;
 		ReorderableList m_RuleList;
 
-		new void OnEnable()
+		private float k_DefaultElementHeight { get { return RuleTileEditor.k_DefaultElementHeight; } }
+		private float k_PaddingBetweenRules { get { return RuleTileEditor.k_PaddingBetweenRules; } }
+		private float k_SingleLineHeight { get { return RuleTileEditor.k_SingleLineHeight; } }
+		private float k_LabelWidth { get { return RuleTileEditor.k_LabelWidth; } }
+
+		void OnEnable()
 		{
 			if (m_Sprites == null)
 				m_Sprites = new List<KeyValuePair<Sprite, Sprite>>();
@@ -33,8 +37,8 @@ namespace UnityEditor
 				overrideTile.GetOverrides(m_Sprites);
 
 				m_SpriteList = new ReorderableList(m_Sprites, typeof(KeyValuePair<Sprite, Sprite>), false, true, false, false);
-				m_SpriteList.drawElementCallback = DrawSpriteElement;
 				m_SpriteList.drawHeaderCallback = DrawSpriteHeader;
+				m_SpriteList.drawElementCallback = DrawSpriteElement;
 				m_SpriteList.elementHeight = k_DefaultElementHeight + k_PaddingBetweenRules;
 			}
 			if (m_RuleList == null)
@@ -42,8 +46,8 @@ namespace UnityEditor
 				overrideTile.GetOverrides(m_Rules);
 
 				m_RuleList = new ReorderableList(m_Rules, typeof(KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRule>), false, true, false, false);
-				m_RuleList.drawElementCallback = DrawRuleElement;
 				m_RuleList.drawHeaderCallback = DrawRuleHeader;
+				m_RuleList.drawElementCallback = DrawRuleElement;
 				m_RuleList.elementHeightCallback = GetRuleElementHeight;
 			}
 		}
@@ -87,6 +91,12 @@ namespace UnityEditor
 			}
 		}
 
+		private void SaveTile()
+		{
+			EditorUtility.SetDirty(target);
+			SceneView.RepaintAll();
+		}
+
 		private void DrawSpriteElement(Rect rect, int index, bool selected, bool focused)
 		{
 			Sprite originalSprite = m_Sprites[index].Key;
@@ -121,8 +131,6 @@ namespace UnityEditor
 
 		private void DrawRuleElement(Rect rect, int index, bool selected, bool focused)
 		{
-			overrideTile.Override();
-
 			RuleTile.TilingRule originalRule = m_Rules[index].Key;
 			RuleTile.TilingRule overrideRule = m_Rules[index].Value;
 
@@ -160,11 +168,11 @@ namespace UnityEditor
 				Rect spriteRect = new Rect(rect.xMax - matrixWidth - 5f, yPos, matrixWidth, k_DefaultElementHeight);
 
 				if (!isDefault)
-					RuleInspectorOnGUI(inspectorRect, originalRule);
+					RuleTileEditor.RuleInspectorOnGUI(inspectorRect, originalRule);
 				else
 					RuleOriginalDefaultInspectorOnGUI(inspectorRect, originalRule);
-				RuleMatrixOnGUI(matrixRect, originalRule);
-				SpriteOnGUI(spriteRect, originalRule);
+				RuleTileEditor.RuleMatrixOnGUI(matrixRect, originalRule);
+				RuleTileEditor.SpriteOnGUI(spriteRect, originalRule);
 			}
 		}
 		private void DrawOverrideElement(Rect rect, RuleTile.TilingRule originalRule)
@@ -179,7 +187,7 @@ namespace UnityEditor
 			RuleOverrideInspectorOnGUI(inspectorRect, originalRule);
 			RuleTile.TilingRule overrideRule = overrideTile[originalRule];
 			if (overrideRule != null)
-				SpriteOnGUI(spriteRect, overrideRule);
+				RuleTileEditor.SpriteOnGUI(spriteRect, overrideRule);
 		}
 		private void RuleOriginalDefaultInspectorOnGUI(Rect rect, RuleTile.TilingRule originalRule)
 		{
@@ -267,7 +275,7 @@ namespace UnityEditor
 
 			RuleOverrideDefaultInspectorOnGUI(inspectorRect, originalRule);
 			if (overrideTile.m_OverrideDefault.m_Enabled)
-				SpriteOnGUI(spriteRect, overrideTile.m_OverrideDefault.m_TilingRule);
+				RuleTileEditor.SpriteOnGUI(spriteRect, overrideTile.m_OverrideDefault.m_TilingRule);
 		}
 		private void RuleOverrideDefaultInspectorOnGUI(Rect rect, RuleTile.TilingRule overrideRule)
 		{
@@ -293,6 +301,8 @@ namespace UnityEditor
 		}
 		private void DrawRuleHeader(Rect rect)
 		{
+			overrideTile.Override();
+
 			float matrixWidth = k_DefaultElementHeight;
 
 			float xMax = rect.xMax;

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs.meta
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd977390416471341b10fd1278290da0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
@@ -210,10 +210,11 @@ namespace UnityEngine
 			{
 				if (m_RuntimeTile.m_DefaultSprite)
 					m_RuntimeTile.m_DefaultSprite = this[m_RuntimeTile.m_DefaultSprite];
-				foreach (RuleTile.TilingRule rule in m_RuntimeTile.m_TilingRules)
-					for (int i = 0; i < rule.m_Sprites.Length; i++)
-						if (rule.m_Sprites[i])
-							rule.m_Sprites[i] = this[rule.m_Sprites[i]];
+				if (m_RuntimeTile.m_TilingRules != null)
+					foreach (RuleTile.TilingRule rule in m_RuntimeTile.m_TilingRules)
+						for (int i = 0; i < rule.m_Sprites.Length; i++)
+							if (rule.m_Sprites[i])
+								rule.m_Sprites[i] = this[rule.m_Sprites[i]];
 			}
 			else
 			{
@@ -222,13 +223,15 @@ namespace UnityEngine
 					m_RuntimeTile.m_DefaultSprite = m_OverrideDefault.m_TilingRule.m_Sprites.Length > 0 ? m_OverrideDefault.m_TilingRule.m_Sprites[0] : null;
 					m_RuntimeTile.m_DefaultColliderType = m_OverrideDefault.m_TilingRule.m_ColliderType;
 				}
-				for (int i = 0; i < m_RuntimeTile.m_TilingRules.Count; i++)
-				{
-					RuleTile.TilingRule originalRule = m_RuntimeTile.m_TilingRules[i];
-					RuleTile.TilingRule overrideRule = this[m_Tile.m_TilingRules[i]];
-					if (overrideRule == null)
-						continue;
-					CopyTilingRule(overrideRule, originalRule, false);
+				if (m_RuntimeTile.m_TilingRules != null) {
+					for (int i = 0; i < m_RuntimeTile.m_TilingRules.Count; i++)
+					{
+						RuleTile.TilingRule originalRule = m_RuntimeTile.m_TilingRules[i];
+						RuleTile.TilingRule overrideRule = this[m_Tile.m_TilingRules[i]];
+						if (overrideRule == null)
+							continue;
+						CopyTilingRule(overrideRule, originalRule, false);
+					}
 				}
 			}
 		}

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
@@ -57,7 +57,7 @@ namespace UnityEngine
 		}
 
 		public RuleTile m_Tile;
-		public List<TileSpritePair> m_Sprites;
+		public List<TileSpritePair> m_Sprites = new List<TileSpritePair>();
 
 		public override void GetTileData(Vector3Int position, ITilemap tileMap, ref TileData tileData)
 		{

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
@@ -5,18 +5,22 @@ using UnityEngine.Tilemaps;
 
 namespace UnityEngine
 {
-
-	[Serializable]
-	public class TileSpritePair
-	{
-		public Sprite m_OriginalSprite;
-		public Sprite m_OverrideSprite;
-	}
-
 	[Serializable]
 	[CreateAssetMenu]
 	public class RuleOverrideTile : RuleTile
 	{
+		[Serializable]
+		public class TileSpritePair
+		{
+			public Sprite m_OriginalSprite;
+			public Sprite m_OverrideSprite;
+		}
+		[Serializable]
+		public class OverrideTilingRule
+		{
+			public bool m_Enabled;
+			public TilingRule m_TilingRule = new TilingRule();
+		}
 
 		public Sprite this[Sprite originalSprite]
 		{
@@ -55,28 +59,70 @@ namespace UnityEngine
 				}
 			}
 		}
+		public TilingRule this[TilingRule originalRule]
+		{
+			get
+			{
+				if (!m_Tile)
+					return null;
+
+				int index = m_Tile.m_TilingRules.IndexOf(originalRule);
+				if (index == -1)
+					return null;
+				if (m_OverrideTilingRules.Count < index + 1)
+					return null;
+
+				return m_OverrideTilingRules[index].m_Enabled ? m_OverrideTilingRules[index].m_TilingRule : null;
+			}
+			set
+			{
+				if (!m_Tile)
+					return;
+
+				int index = m_Tile.m_TilingRules.IndexOf(originalRule);
+				if (index == -1)
+					return;
+
+				if (value == null)
+				{
+					if (m_OverrideTilingRules.Count < index + 1)
+						return;
+					m_OverrideTilingRules[index].m_Enabled = false;
+					while (m_OverrideTilingRules.Count > 0 && !m_OverrideTilingRules[m_OverrideTilingRules.Count - 1].m_Enabled)
+						m_OverrideTilingRules.RemoveAt(m_OverrideTilingRules.Count - 1);
+				}
+				else
+				{
+					while (m_OverrideTilingRules.Count < index + 1)
+						m_OverrideTilingRules.Add(new OverrideTilingRule());
+					m_OverrideTilingRules[index].m_Enabled = true;
+					m_OverrideTilingRules[index].m_TilingRule = CloneTilingRule(value);
+					m_OverrideTilingRules[index].m_TilingRule.m_Neighbors = null;
+				}
+			}
+		}
 
 		public RuleTile m_Tile;
+		public bool m_Advanced;
 		public List<TileSpritePair> m_Sprites = new List<TileSpritePair>();
+		public List<OverrideTilingRule> m_OverrideTilingRules = new List<OverrideTilingRule>();
+		public OverrideTilingRule m_OverrideDefault = new OverrideTilingRule();
+		public TilingRule m_OriginalDefault
+		{
+			get
+			{
+				return new TilingRule()
+				{
+					m_Sprites = new Sprite[] { m_Tile != null ? m_Tile.m_DefaultSprite : null },
+					m_ColliderType = m_Tile != null ? m_Tile.m_DefaultColliderType : Tile.ColliderType.None,
+				};
+			}
+		}
 
-		public override void GetTileData(Vector3Int position, ITilemap tileMap, ref TileData tileData)
+		public override bool StartUp(Vector3Int position, ITilemap tilemap, GameObject go)
 		{
-			CopyRules();
-			base.GetTileData(position, tileMap, ref tileData);
-			tileData.sprite = tileData.sprite ? this[tileData.sprite] : null;
-		}
-		public override bool GetTileAnimationData(Vector3Int position, ITilemap tilemap, ref TileAnimationData tileAnimationData)
-		{
-			CopyRules();
-			bool match = base.GetTileAnimationData(position, tilemap, ref tileAnimationData);
-			if (tileAnimationData.animatedSprites != null)
-				tileAnimationData.animatedSprites = tileAnimationData.animatedSprites.Select(sprite => sprite ? this[sprite] : null).ToArray();
-			return match;
-		}
-		public override void RefreshTile(Vector3Int location, ITilemap tileMap)
-		{
-			CopyRules();
-			base.RefreshTile(location, tileMap);
+			Override();
+			return base.StartUp(position, tilemap, go);
 		}
 
 		public void ApplyOverrides(IList<KeyValuePair<Sprite, Sprite>> overrides)
@@ -110,15 +156,85 @@ namespace UnityEngine
 			foreach (Sprite sprite in originalSprites)
 				overrides.Add(new KeyValuePair<Sprite, Sprite>(sprite, this[sprite]));
 		}
-
-		private void CopyRules()
+		public void ApplyOverrides(IList<KeyValuePair<TilingRule, TilingRule>> overrides)
 		{
+			if (overrides == null)
+				throw new System.ArgumentNullException("overrides");
+
+			for (int i = 0; i < overrides.Count; i++)
+				this[overrides[i].Key] = overrides[i].Value;
+		}
+		public void GetOverrides(List<KeyValuePair<TilingRule, TilingRule>> overrides)
+		{
+			if (overrides == null)
+				throw new System.ArgumentNullException("overrides");
+
+			overrides.Clear();
+
 			if (!m_Tile)
 				return;
 
-			m_DefaultSprite = m_Tile.m_DefaultSprite;
-			m_DefaultColliderType = m_Tile.m_DefaultColliderType;
-			m_TilingRules = m_Tile.m_TilingRules;
+			foreach (var originalRule in m_Tile.m_TilingRules)
+			{
+				TilingRule overrideRule = this[originalRule];
+				overrides.Add(new KeyValuePair<TilingRule, TilingRule>(originalRule, overrideRule));
+			}
+			overrides.Add(new KeyValuePair<TilingRule, TilingRule>(m_OriginalDefault, m_OverrideDefault.m_TilingRule));
+		}
+
+		public void Override()
+		{
+			if (m_Tile)
+			{
+				m_DefaultSprite = m_Tile.m_DefaultSprite;
+				m_DefaultColliderType = m_Tile.m_DefaultColliderType;
+				m_TilingRules = m_Tile.m_TilingRules.Select(rule => CloneTilingRule(rule)).ToList();
+			}
+			if (!m_Advanced)
+			{
+				if (m_DefaultSprite)
+					m_DefaultSprite = this[m_DefaultSprite];
+				foreach (RuleTile.TilingRule rule in m_TilingRules)
+					for (int i = 0; i < rule.m_Sprites.Length; i++)
+						if (rule.m_Sprites[i])
+							rule.m_Sprites[i] = this[rule.m_Sprites[i]];
+			}
+			else
+			{
+				if (m_OverrideDefault.m_Enabled)
+				{
+					m_DefaultSprite = m_OverrideDefault.m_TilingRule.m_Sprites.Length > 0 ? m_OverrideDefault.m_TilingRule.m_Sprites[0] : null;
+					m_DefaultColliderType = m_OverrideDefault.m_TilingRule.m_ColliderType;
+				}
+				for (int i = 0; i < m_TilingRules.Count; i++)
+				{
+					var originalRule = m_TilingRules[i];
+					TilingRule overrideRule = this[m_Tile.m_TilingRules[i]];
+					if (overrideRule == null)
+						continue;
+					CopyTilingRule(overrideRule, originalRule, false);
+				}
+			}
+		}
+		public TilingRule CloneTilingRule(TilingRule from)
+		{
+			var clone = new TilingRule();
+			CopyTilingRule(from, clone, true);
+			return clone;
+		}
+		public void CopyTilingRule(TilingRule from, TilingRule to, bool copyRule)
+		{
+			if (copyRule)
+			{
+				to.m_Neighbors = from.m_Neighbors;
+				to.m_RuleTransform = from.m_RuleTransform;
+			}
+			to.m_Sprites = from.m_Sprites.Clone() as Sprite[];
+			to.m_AnimationSpeed = from.m_AnimationSpeed;
+			to.m_PerlinScale = from.m_PerlinScale;
+			to.m_Output = from.m_Output;
+			to.m_ColliderType = from.m_ColliderType;
+			to.m_RandomTransform = from.m_RandomTransform;
 		}
 	}
 }

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.Tilemaps;
+
+namespace UnityEngine
+{
+
+	[Serializable]
+	public class TileSpritePair
+	{
+		public Sprite m_OriginalSprite;
+		public Sprite m_OverrideSprite;
+	}
+
+	[Serializable]
+	[CreateAssetMenu]
+	public class RuleOverrideTile : RuleTile
+	{
+
+		public Sprite this[Sprite originalSprite]
+		{
+			get
+			{
+				foreach (TileSpritePair spritePair in m_Sprites)
+				{
+					if (spritePair.m_OriginalSprite == originalSprite)
+					{
+						return spritePair.m_OverrideSprite;
+					}
+				}
+				return null;
+			}
+			set
+			{
+				if (value == null)
+				{
+					m_Sprites = m_Sprites.Where(spritePair => spritePair.m_OriginalSprite != originalSprite).ToList();
+				}
+				else
+				{
+					foreach (TileSpritePair spritePair in m_Sprites)
+					{
+						if (spritePair.m_OriginalSprite == originalSprite)
+						{
+							spritePair.m_OverrideSprite = value;
+							return;
+						}
+					}
+					m_Sprites.Add(new TileSpritePair()
+					{
+						m_OriginalSprite = originalSprite,
+						m_OverrideSprite = value,
+					});
+				}
+			}
+		}
+
+		public RuleTile m_Tile;
+		public List<TileSpritePair> m_Sprites;
+
+		public override void GetTileData(Vector3Int position, ITilemap tileMap, ref TileData tileData)
+		{
+			CopyRules();
+			base.GetTileData(position, tileMap, ref tileData);
+			tileData.sprite = tileData.sprite ? this[tileData.sprite] : null;
+		}
+		public override bool GetTileAnimationData(Vector3Int position, ITilemap tilemap, ref TileAnimationData tileAnimationData)
+		{
+			CopyRules();
+			bool match = base.GetTileAnimationData(position, tilemap, ref tileAnimationData);
+			if (tileAnimationData.animatedSprites != null)
+				tileAnimationData.animatedSprites = tileAnimationData.animatedSprites.Select(sprite => sprite ? this[sprite] : null).ToArray();
+			return match;
+		}
+		public override void RefreshTile(Vector3Int location, ITilemap tileMap)
+		{
+			CopyRules();
+			base.RefreshTile(location, tileMap);
+		}
+
+		public void ApplyOverrides(IList<KeyValuePair<Sprite, Sprite>> overrides)
+		{
+			if (overrides == null)
+				throw new System.ArgumentNullException("overrides");
+
+			for (int i = 0; i < overrides.Count; i++)
+				this[overrides[i].Key] = overrides[i].Value;
+		}
+		public void GetOverrides(List<KeyValuePair<Sprite, Sprite>> overrides)
+		{
+			if (overrides == null)
+				throw new System.ArgumentNullException("overrides");
+
+			overrides.Clear();
+
+			if (!m_Tile)
+				return;
+
+			List<Sprite> originalSprites = new List<Sprite>();
+
+			if (m_Tile.m_DefaultSprite)
+				originalSprites.Add(m_Tile.m_DefaultSprite);
+
+			foreach (RuleTile.TilingRule rule in m_Tile.m_TilingRules)
+				foreach (Sprite sprite in rule.m_Sprites)
+					if (sprite && !originalSprites.Contains(sprite))
+						originalSprites.Add(sprite);
+
+			foreach (Sprite sprite in originalSprites)
+				overrides.Add(new KeyValuePair<Sprite, Sprite>(sprite, this[sprite]));
+		}
+
+		private void CopyRules()
+		{
+			if (!m_Tile)
+				return;
+
+			m_DefaultSprite = m_Tile.m_DefaultSprite;
+			m_DefaultColliderType = m_Tile.m_DefaultColliderType;
+			m_TilingRules = m_Tile.m_TilingRules;
+		}
+	}
+}

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs.meta
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c779848d9dd029409ca676b49e10a18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
@@ -14,20 +14,20 @@ namespace UnityEditor
 	[CanEditMultipleObjects]
 	internal class RuleTileEditor : Editor
 	{
-		private const string s_XIconString = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABoSURBVDhPnY3BDcAgDAOZhS14dP1O0x2C/LBEgiNSHvfwyZabmV0jZRUpq2zi6f0DJwdcQOEdwwDLypF0zHLMa9+NQRxkQ+ACOT2STVw/q8eY1346ZlE54sYAhVhSDrjwFymrSFnD2gTZpls2OvFUHAAAAABJRU5ErkJggg==";
-		private const string s_Arrow0 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPzZExDoQwDATzE4oU4QXXcgUFj+YxtETwgpMwXuFcwMFSRMVKKwzZcWzhiMg91jtg34XIntkre5EaT7yjjhI9pOD5Mw5k2X/DdUwFr3cQ7Pu23E/BiwXyWSOxrNqx+ewnsayam5OLBtbOGPUM/r93YZL4/dhpR/amwByGFBz170gNChA6w5bQQMqramBTgJ+Z3A58WuWejPCaHQAAAABJRU5ErkJggg==";
-		private const string s_Arrow1 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPxYzBDYAgEATpxYcd+PVr0fZ2siZrjmMhFz6STIiDs8XMlpEyi5RkO/d66TcgJUB43JfNBqRkSEYDnYjhbKD5GIUkDqRDwoH3+NgTAw+bL/aoOP4DOgH+iwECEt+IlFmkzGHlAYKAWF9R8zUnAAAAAElFTkSuQmCC";
-		private const string s_Arrow2 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAC0SURBVDhPjVE5EsIwDMxPKFKYF9CagoJH8xhaMskLmEGsjOSRkBzYmU2s9a58TUQUmCH1BWEHweuKP+D8tphrWcAHuIGrjPnPNY8X2+DzEWE+FzrdrkNyg2YGNNfRGlyOaZDJOxBrDhgOowaYW8UW0Vau5ZkFmXbbDr+CzOHKmLinAXMEePyZ9dZkZR+s5QX2O8DY3zZ/sgYcdDqeEVp8516o0QQV1qeMwg6C91toYoLoo+kNt/tpKQEVvFQAAAAASUVORK5CYII=";
-		private const string s_Arrow3 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAB2SURBVDhPzY1LCoAwEEPnLi48gW5d6p31bH5SMhp0Cq0g+CCLxrzRPqMZ2pRqKG4IqzJc7JepTlbRZXYpWTg4RZE1XAso8VHFKNhQuTjKtZvHUNCEMogO4K3BhvMn9wP4EzoPZ3n0AGTW5fiBVzLAAYTP32C2Ay3agtu9V/9PAAAAAElFTkSuQmCC";
-		private const string s_Arrow5 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPnY3BCYBADASvFx924NevRdvbyoLBmNuDJQMDGjNxAFhK1DyUQ9fvobCdO+j7+sOKj/uSB+xYHZAxl7IR1wNTXJeVcaAVU+614uWfCT9mVUhknMlxDokd15BYsQrJFHeUQ0+MB5ErsPi/6hO1AAAAAElFTkSuQmCC";
-		private const string s_Arrow6 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACaSURBVDhPxZExEkAwEEVzE4UiTqClUDi0w2hlOIEZsV82xCZmQuPPfFn8t1mirLWf7S5flQOXjd64vCuEKWTKVt+6AayH3tIa7yLg6Qh2FcKFB72jBgJeziA1CMHzeaNHjkfwnAK86f3KUafU2ClHIJSzs/8HHLv09M3SaMCxS7ljw/IYJWzQABOQZ66x4h614ahTCL/WT7BSO51b5Z5hSx88AAAAAElFTkSuQmCC";
-		private const string s_Arrow7 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABQSURBVDhPYxh8QNle/T8U/4MKEQdAmsz2eICx6W530gygr2aQBmSMphkZYxqErAEXxusKfAYQ7XyyNMIAsgEkaYQBkAFkaYQBsjXSGDAwAAD193z4luKPrAAAAABJRU5ErkJggg==";
-		private const string s_Arrow8 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPxZE9DoAwCIW9iUOHegJXHRw8tIdx1egJTMSHAeMPaHSR5KVQ+KCkCRF91mdz4VDEWVzXTBgg5U1N5wahjHzXS3iFFVRxAygNVaZxJ6VHGIl2D6oUXP0ijlJuTp724FnID1Lq7uw2QM5+thoKth0N+GGyA7IA3+yM77Ag1e2zkey5gCdAg/h8csy+/89v7E+YkgUntOWeVt2SfAAAAABJRU5ErkJggg==";
-		private const string s_MirrorX = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG1JREFUOE+lj9ENwCAIRB2IFdyRfRiuDSaXAF4MrR9P5eRhHGb2Gxp2oaEjIovTXSrAnPNx6hlgyCZ7o6omOdYOldGIZhAziEmOTSfigLV0RYAB9y9f/7kO8L3WUaQyhCgz0dmCL9CwCw172HgBeyG6oloC8fAAAAAASUVORK5CYII=";
-		private const string s_MirrorY = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG9JREFUOE+djckNACEMAykoLdAjHbPyw1IOJ0L7mAejjFlm9hspyd77Kk+kBAjPOXcakJIh6QaKyOE0EB5dSPJAiUmOiL8PMVGxugsP/0OOib8vsY8yYwy6gRyC8CB5QIWgCMKBLgRSkikEUr5h6wOPWfMoCYILdgAAAABJRU5ErkJggg==";
-		private const string s_Rotated = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAHdJREFUOE+djssNwCAMQxmIFdgx+2S4Vj4YxWlQgcOT8nuG5u5C732Sd3lfLlmPMR4QhXgrTQaimUlA3EtD+CJlBuQ7aUAUMjEAv9gWCQNEPhHJUkYfZ1kEpcxDzioRzGIlr0Qwi0r+Q5rTgM+AAVcygHgt7+HtBZs/2QVWP8ahAAAAAElFTkSuQmCC";
+		protected const string s_XIconString = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABoSURBVDhPnY3BDcAgDAOZhS14dP1O0x2C/LBEgiNSHvfwyZabmV0jZRUpq2zi6f0DJwdcQOEdwwDLypF0zHLMa9+NQRxkQ+ACOT2STVw/q8eY1346ZlE54sYAhVhSDrjwFymrSFnD2gTZpls2OvFUHAAAAABJRU5ErkJggg==";
+		protected const string s_Arrow0 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPzZExDoQwDATzE4oU4QXXcgUFj+YxtETwgpMwXuFcwMFSRMVKKwzZcWzhiMg91jtg34XIntkre5EaT7yjjhI9pOD5Mw5k2X/DdUwFr3cQ7Pu23E/BiwXyWSOxrNqx+ewnsayam5OLBtbOGPUM/r93YZL4/dhpR/amwByGFBz170gNChA6w5bQQMqramBTgJ+Z3A58WuWejPCaHQAAAABJRU5ErkJggg==";
+		protected const string s_Arrow1 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPxYzBDYAgEATpxYcd+PVr0fZ2siZrjmMhFz6STIiDs8XMlpEyi5RkO/d66TcgJUB43JfNBqRkSEYDnYjhbKD5GIUkDqRDwoH3+NgTAw+bL/aoOP4DOgH+iwECEt+IlFmkzGHlAYKAWF9R8zUnAAAAAElFTkSuQmCC";
+		protected const string s_Arrow2 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAC0SURBVDhPjVE5EsIwDMxPKFKYF9CagoJH8xhaMskLmEGsjOSRkBzYmU2s9a58TUQUmCH1BWEHweuKP+D8tphrWcAHuIGrjPnPNY8X2+DzEWE+FzrdrkNyg2YGNNfRGlyOaZDJOxBrDhgOowaYW8UW0Vau5ZkFmXbbDr+CzOHKmLinAXMEePyZ9dZkZR+s5QX2O8DY3zZ/sgYcdDqeEVp8516o0QQV1qeMwg6C91toYoLoo+kNt/tpKQEVvFQAAAAASUVORK5CYII=";
+		protected const string s_Arrow3 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAB2SURBVDhPzY1LCoAwEEPnLi48gW5d6p31bH5SMhp0Cq0g+CCLxrzRPqMZ2pRqKG4IqzJc7JepTlbRZXYpWTg4RZE1XAso8VHFKNhQuTjKtZvHUNCEMogO4K3BhvMn9wP4EzoPZ3n0AGTW5fiBVzLAAYTP32C2Ay3agtu9V/9PAAAAAElFTkSuQmCC";
+		protected const string s_Arrow5 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPnY3BCYBADASvFx924NevRdvbyoLBmNuDJQMDGjNxAFhK1DyUQ9fvobCdO+j7+sOKj/uSB+xYHZAxl7IR1wNTXJeVcaAVU+614uWfCT9mVUhknMlxDokd15BYsQrJFHeUQ0+MB5ErsPi/6hO1AAAAAElFTkSuQmCC";
+		protected const string s_Arrow6 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACaSURBVDhPxZExEkAwEEVzE4UiTqClUDi0w2hlOIEZsV82xCZmQuPPfFn8t1mirLWf7S5flQOXjd64vCuEKWTKVt+6AayH3tIa7yLg6Qh2FcKFB72jBgJeziA1CMHzeaNHjkfwnAK86f3KUafU2ClHIJSzs/8HHLv09M3SaMCxS7ljw/IYJWzQABOQZ66x4h614ahTCL/WT7BSO51b5Z5hSx88AAAAAElFTkSuQmCC";
+		protected const string s_Arrow7 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABQSURBVDhPYxh8QNle/T8U/4MKEQdAmsz2eICx6W530gygr2aQBmSMphkZYxqErAEXxusKfAYQ7XyyNMIAsgEkaYQBkAFkaYQBsjXSGDAwAAD193z4luKPrAAAAABJRU5ErkJggg==";
+		protected const string s_Arrow8 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPxZE9DoAwCIW9iUOHegJXHRw8tIdx1egJTMSHAeMPaHSR5KVQ+KCkCRF91mdz4VDEWVzXTBgg5U1N5wahjHzXS3iFFVRxAygNVaZxJ6VHGIl2D6oUXP0ijlJuTp724FnID1Lq7uw2QM5+thoKth0N+GGyA7IA3+yM77Ag1e2zkey5gCdAg/h8csy+/89v7E+YkgUntOWeVt2SfAAAAABJRU5ErkJggg==";
+		protected const string s_MirrorX = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG1JREFUOE+lj9ENwCAIRB2IFdyRfRiuDSaXAF4MrR9P5eRhHGb2Gxp2oaEjIovTXSrAnPNx6hlgyCZ7o6omOdYOldGIZhAziEmOTSfigLV0RYAB9y9f/7kO8L3WUaQyhCgz0dmCL9CwCw172HgBeyG6oloC8fAAAAAASUVORK5CYII=";
+		protected const string s_MirrorY = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG9JREFUOE+djckNACEMAykoLdAjHbPyw1IOJ0L7mAejjFlm9hspyd77Kk+kBAjPOXcakJIh6QaKyOE0EB5dSPJAiUmOiL8PMVGxugsP/0OOib8vsY8yYwy6gRyC8CB5QIWgCMKBLgRSkikEUr5h6wOPWfMoCYILdgAAAABJRU5ErkJggg==";
+		protected const string s_Rotated = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAHdJREFUOE+djssNwCAMQxmIFdgx+2S4Vj4YxWlQgcOT8nuG5u5C732Sd3lfLlmPMR4QhXgrTQaimUlA3EtD+CJlBuQ7aUAUMjEAv9gWCQNEPhHJUkYfZ1kEpcxDzioRzGIlr0Qwi0r+Q5rTgM+AAVcygHgt7+HtBZs/2QVWP8ahAAAAAElFTkSuQmCC";
 		
-		private static Texture2D[] s_Arrows;
+		protected static Texture2D[] s_Arrows;
 		public static Texture2D[] arrows
 		{
 			get
@@ -49,7 +49,7 @@ namespace UnityEditor
 			}
 		}
 
-		private static Texture2D[] s_AutoTransforms;
+		protected static Texture2D[] s_AutoTransforms;
 		public static Texture2D[] autoTransforms
 		{
 			get
@@ -65,14 +65,14 @@ namespace UnityEditor
 			}
 		}
 		
-		private ReorderableList m_ReorderableList;
+		protected ReorderableList m_ReorderableList;
 		public RuleTile tile { get { return (target as RuleTile); } }
-		private Rect m_ListRect;
+		protected Rect m_ListRect;
 
-		const float k_DefaultElementHeight = 48f;
-		const float k_PaddingBetweenRules = 13f;
-		const float k_SingleLineHeight = 16f;
-		const float k_LabelWidth = 53f;
+		protected const float k_DefaultElementHeight = 48f;
+		protected const float k_PaddingBetweenRules = 13f;
+		protected const float k_SingleLineHeight = 16f;
+		protected const float k_LabelWidth = 53f;
 			
 		public void OnEnable()
 		{
@@ -86,12 +86,12 @@ namespace UnityEditor
 			m_ReorderableList.onReorderCallback = ListUpdated;
 		}
 
-		private void ListUpdated(ReorderableList list)
+		protected void ListUpdated(ReorderableList list)
 		{
 			SaveTile();
 		}
 
-		private float GetElementHeight(int index)
+		protected float GetElementHeight(int index)
 		{
 			if (tile.m_TilingRules != null && tile.m_TilingRules.Count > 0)
 			{
@@ -106,7 +106,7 @@ namespace UnityEditor
 			return k_DefaultElementHeight + k_PaddingBetweenRules;
 		}
 
-		private void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
+		protected void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
 		{
 			RuleTile.TilingRule rule = tile.m_TilingRules[index];
 
@@ -126,13 +126,13 @@ namespace UnityEditor
 				SaveTile();
 		}
 
-		private void SaveTile()
+		protected void SaveTile()
 		{
 			EditorUtility.SetDirty(target);
 			SceneView.RepaintAll();
 		}
 
-		private void OnDrawHeader(Rect rect)
+		protected void OnDrawHeader(Rect rect)
 		{
 			GUI.Label(rect, "Tiling Rules");
 		}
@@ -147,7 +147,7 @@ namespace UnityEditor
 				m_ReorderableList.DoLayoutList();
 		}
 
-		private static void RuleMatrixOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+		protected static void RuleMatrixOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
 		{
 			Handles.color = EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.2f) : new Color(0f, 0f, 0f, 0.2f);
 			int index = 0;
@@ -220,13 +220,13 @@ namespace UnityEditor
 			}
 		}
 
-		private static void OnSelect(object userdata)
+		protected static void OnSelect(object userdata)
 		{
 			MenuItemData data = (MenuItemData) userdata;
 			data.m_Rule.m_RuleTransform = data.m_NewValue;
 		}
 
-		private class MenuItemData
+		protected class MenuItemData
 		{
 			public RuleTile.TilingRule m_Rule;
 			public RuleTile.TilingRule.Transform m_NewValue;
@@ -238,12 +238,12 @@ namespace UnityEditor
 			}
 		}
 
-		private void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+		protected void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
 		{
 			tilingRule.m_Sprites[0] = EditorGUI.ObjectField(new Rect(rect.xMax - rect.height, rect.yMin, rect.height, rect.height), tilingRule.m_Sprites[0], typeof (Sprite), false) as Sprite;
 		}
 
-		private static void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+		protected static void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
 		{
 			float y = rect.yMin;
 			EditorGUI.BeginChangeCheck();
@@ -310,7 +310,7 @@ namespace UnityEditor
 			return base.RenderStaticPreview(assetPath, subAssets, width, height);
 		}
 
-		private static Type GetType(string TypeName)
+		protected static Type GetType(string TypeName)
 		{
 			var type = Type.GetType(TypeName);
 			if (type != null)
@@ -342,7 +342,7 @@ namespace UnityEditor
 			return null;
 		}
 
-		private static Texture2D Base64ToTexture(string base64)
+		protected static Texture2D Base64ToTexture(string base64)
 		{
 			Texture2D t = new Texture2D(1, 1);
 			t.hideFlags = HideFlags.HideAndDontSave;

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
@@ -14,20 +14,20 @@ namespace UnityEditor
 	[CanEditMultipleObjects]
 	internal class RuleTileEditor : Editor
 	{
-		protected const string s_XIconString = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABoSURBVDhPnY3BDcAgDAOZhS14dP1O0x2C/LBEgiNSHvfwyZabmV0jZRUpq2zi6f0DJwdcQOEdwwDLypF0zHLMa9+NQRxkQ+ACOT2STVw/q8eY1346ZlE54sYAhVhSDrjwFymrSFnD2gTZpls2OvFUHAAAAABJRU5ErkJggg==";
-		protected const string s_Arrow0 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPzZExDoQwDATzE4oU4QXXcgUFj+YxtETwgpMwXuFcwMFSRMVKKwzZcWzhiMg91jtg34XIntkre5EaT7yjjhI9pOD5Mw5k2X/DdUwFr3cQ7Pu23E/BiwXyWSOxrNqx+ewnsayam5OLBtbOGPUM/r93YZL4/dhpR/amwByGFBz170gNChA6w5bQQMqramBTgJ+Z3A58WuWejPCaHQAAAABJRU5ErkJggg==";
-		protected const string s_Arrow1 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPxYzBDYAgEATpxYcd+PVr0fZ2siZrjmMhFz6STIiDs8XMlpEyi5RkO/d66TcgJUB43JfNBqRkSEYDnYjhbKD5GIUkDqRDwoH3+NgTAw+bL/aoOP4DOgH+iwECEt+IlFmkzGHlAYKAWF9R8zUnAAAAAElFTkSuQmCC";
-		protected const string s_Arrow2 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAC0SURBVDhPjVE5EsIwDMxPKFKYF9CagoJH8xhaMskLmEGsjOSRkBzYmU2s9a58TUQUmCH1BWEHweuKP+D8tphrWcAHuIGrjPnPNY8X2+DzEWE+FzrdrkNyg2YGNNfRGlyOaZDJOxBrDhgOowaYW8UW0Vau5ZkFmXbbDr+CzOHKmLinAXMEePyZ9dZkZR+s5QX2O8DY3zZ/sgYcdDqeEVp8516o0QQV1qeMwg6C91toYoLoo+kNt/tpKQEVvFQAAAAASUVORK5CYII=";
-		protected const string s_Arrow3 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAB2SURBVDhPzY1LCoAwEEPnLi48gW5d6p31bH5SMhp0Cq0g+CCLxrzRPqMZ2pRqKG4IqzJc7JepTlbRZXYpWTg4RZE1XAso8VHFKNhQuTjKtZvHUNCEMogO4K3BhvMn9wP4EzoPZ3n0AGTW5fiBVzLAAYTP32C2Ay3agtu9V/9PAAAAAElFTkSuQmCC";
-		protected const string s_Arrow5 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPnY3BCYBADASvFx924NevRdvbyoLBmNuDJQMDGjNxAFhK1DyUQ9fvobCdO+j7+sOKj/uSB+xYHZAxl7IR1wNTXJeVcaAVU+614uWfCT9mVUhknMlxDokd15BYsQrJFHeUQ0+MB5ErsPi/6hO1AAAAAElFTkSuQmCC";
-		protected const string s_Arrow6 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACaSURBVDhPxZExEkAwEEVzE4UiTqClUDi0w2hlOIEZsV82xCZmQuPPfFn8t1mirLWf7S5flQOXjd64vCuEKWTKVt+6AayH3tIa7yLg6Qh2FcKFB72jBgJeziA1CMHzeaNHjkfwnAK86f3KUafU2ClHIJSzs/8HHLv09M3SaMCxS7ljw/IYJWzQABOQZ66x4h614ahTCL/WT7BSO51b5Z5hSx88AAAAAElFTkSuQmCC";
-		protected const string s_Arrow7 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABQSURBVDhPYxh8QNle/T8U/4MKEQdAmsz2eICx6W530gygr2aQBmSMphkZYxqErAEXxusKfAYQ7XyyNMIAsgEkaYQBkAFkaYQBsjXSGDAwAAD193z4luKPrAAAAABJRU5ErkJggg==";
-		protected const string s_Arrow8 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPxZE9DoAwCIW9iUOHegJXHRw8tIdx1egJTMSHAeMPaHSR5KVQ+KCkCRF91mdz4VDEWVzXTBgg5U1N5wahjHzXS3iFFVRxAygNVaZxJ6VHGIl2D6oUXP0ijlJuTp724FnID1Lq7uw2QM5+thoKth0N+GGyA7IA3+yM77Ag1e2zkey5gCdAg/h8csy+/89v7E+YkgUntOWeVt2SfAAAAABJRU5ErkJggg==";
-		protected const string s_MirrorX = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG1JREFUOE+lj9ENwCAIRB2IFdyRfRiuDSaXAF4MrR9P5eRhHGb2Gxp2oaEjIovTXSrAnPNx6hlgyCZ7o6omOdYOldGIZhAziEmOTSfigLV0RYAB9y9f/7kO8L3WUaQyhCgz0dmCL9CwCw172HgBeyG6oloC8fAAAAAASUVORK5CYII=";
-		protected const string s_MirrorY = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG9JREFUOE+djckNACEMAykoLdAjHbPyw1IOJ0L7mAejjFlm9hspyd77Kk+kBAjPOXcakJIh6QaKyOE0EB5dSPJAiUmOiL8PMVGxugsP/0OOib8vsY8yYwy6gRyC8CB5QIWgCMKBLgRSkikEUr5h6wOPWfMoCYILdgAAAABJRU5ErkJggg==";
-		protected const string s_Rotated = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAHdJREFUOE+djssNwCAMQxmIFdgx+2S4Vj4YxWlQgcOT8nuG5u5C732Sd3lfLlmPMR4QhXgrTQaimUlA3EtD+CJlBuQ7aUAUMjEAv9gWCQNEPhHJUkYfZ1kEpcxDzioRzGIlr0Qwi0r+Q5rTgM+AAVcygHgt7+HtBZs/2QVWP8ahAAAAAElFTkSuQmCC";
+		private const string s_XIconString = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABoSURBVDhPnY3BDcAgDAOZhS14dP1O0x2C/LBEgiNSHvfwyZabmV0jZRUpq2zi6f0DJwdcQOEdwwDLypF0zHLMa9+NQRxkQ+ACOT2STVw/q8eY1346ZlE54sYAhVhSDrjwFymrSFnD2gTZpls2OvFUHAAAAABJRU5ErkJggg==";
+		private const string s_Arrow0 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPzZExDoQwDATzE4oU4QXXcgUFj+YxtETwgpMwXuFcwMFSRMVKKwzZcWzhiMg91jtg34XIntkre5EaT7yjjhI9pOD5Mw5k2X/DdUwFr3cQ7Pu23E/BiwXyWSOxrNqx+ewnsayam5OLBtbOGPUM/r93YZL4/dhpR/amwByGFBz170gNChA6w5bQQMqramBTgJ+Z3A58WuWejPCaHQAAAABJRU5ErkJggg==";
+		private const string s_Arrow1 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPxYzBDYAgEATpxYcd+PVr0fZ2siZrjmMhFz6STIiDs8XMlpEyi5RkO/d66TcgJUB43JfNBqRkSEYDnYjhbKD5GIUkDqRDwoH3+NgTAw+bL/aoOP4DOgH+iwECEt+IlFmkzGHlAYKAWF9R8zUnAAAAAElFTkSuQmCC";
+		private const string s_Arrow2 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAC0SURBVDhPjVE5EsIwDMxPKFKYF9CagoJH8xhaMskLmEGsjOSRkBzYmU2s9a58TUQUmCH1BWEHweuKP+D8tphrWcAHuIGrjPnPNY8X2+DzEWE+FzrdrkNyg2YGNNfRGlyOaZDJOxBrDhgOowaYW8UW0Vau5ZkFmXbbDr+CzOHKmLinAXMEePyZ9dZkZR+s5QX2O8DY3zZ/sgYcdDqeEVp8516o0QQV1qeMwg6C91toYoLoo+kNt/tpKQEVvFQAAAAASUVORK5CYII=";
+		private const string s_Arrow3 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAB2SURBVDhPzY1LCoAwEEPnLi48gW5d6p31bH5SMhp0Cq0g+CCLxrzRPqMZ2pRqKG4IqzJc7JepTlbRZXYpWTg4RZE1XAso8VHFKNhQuTjKtZvHUNCEMogO4K3BhvMn9wP4EzoPZ3n0AGTW5fiBVzLAAYTP32C2Ay3agtu9V/9PAAAAAElFTkSuQmCC";
+		private const string s_Arrow5 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABqSURBVDhPnY3BCYBADASvFx924NevRdvbyoLBmNuDJQMDGjNxAFhK1DyUQ9fvobCdO+j7+sOKj/uSB+xYHZAxl7IR1wNTXJeVcaAVU+614uWfCT9mVUhknMlxDokd15BYsQrJFHeUQ0+MB5ErsPi/6hO1AAAAAElFTkSuQmCC";
+		private const string s_Arrow6 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACaSURBVDhPxZExEkAwEEVzE4UiTqClUDi0w2hlOIEZsV82xCZmQuPPfFn8t1mirLWf7S5flQOXjd64vCuEKWTKVt+6AayH3tIa7yLg6Qh2FcKFB72jBgJeziA1CMHzeaNHjkfwnAK86f3KUafU2ClHIJSzs/8HHLv09M3SaMCxS7ljw/IYJWzQABOQZ66x4h614ahTCL/WT7BSO51b5Z5hSx88AAAAAElFTkSuQmCC";
+		private const string s_Arrow7 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAABQSURBVDhPYxh8QNle/T8U/4MKEQdAmsz2eICx6W530gygr2aQBmSMphkZYxqErAEXxusKfAYQ7XyyNMIAsgEkaYQBkAFkaYQBsjXSGDAwAAD193z4luKPrAAAAABJRU5ErkJggg==";
+		private const string s_Arrow8 = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACYSURBVDhPxZE9DoAwCIW9iUOHegJXHRw8tIdx1egJTMSHAeMPaHSR5KVQ+KCkCRF91mdz4VDEWVzXTBgg5U1N5wahjHzXS3iFFVRxAygNVaZxJ6VHGIl2D6oUXP0ijlJuTp724FnID1Lq7uw2QM5+thoKth0N+GGyA7IA3+yM77Ag1e2zkey5gCdAg/h8csy+/89v7E+YkgUntOWeVt2SfAAAAABJRU5ErkJggg==";
+		private const string s_MirrorX = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG1JREFUOE+lj9ENwCAIRB2IFdyRfRiuDSaXAF4MrR9P5eRhHGb2Gxp2oaEjIovTXSrAnPNx6hlgyCZ7o6omOdYOldGIZhAziEmOTSfigLV0RYAB9y9f/7kO8L3WUaQyhCgz0dmCL9CwCw172HgBeyG6oloC8fAAAAAASUVORK5CYII=";
+		private const string s_MirrorY = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAG9JREFUOE+djckNACEMAykoLdAjHbPyw1IOJ0L7mAejjFlm9hspyd77Kk+kBAjPOXcakJIh6QaKyOE0EB5dSPJAiUmOiL8PMVGxugsP/0OOib8vsY8yYwy6gRyC8CB5QIWgCMKBLgRSkikEUr5h6wOPWfMoCYILdgAAAABJRU5ErkJggg==";
+		private const string s_Rotated = "iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAHdJREFUOE+djssNwCAMQxmIFdgx+2S4Vj4YxWlQgcOT8nuG5u5C732Sd3lfLlmPMR4QhXgrTQaimUlA3EtD+CJlBuQ7aUAUMjEAv9gWCQNEPhHJUkYfZ1kEpcxDzioRzGIlr0Qwi0r+Q5rTgM+AAVcygHgt7+HtBZs/2QVWP8ahAAAAAElFTkSuQmCC";
 		
-		protected static Texture2D[] s_Arrows;
+		private static Texture2D[] s_Arrows;
 		public static Texture2D[] arrows
 		{
 			get
@@ -49,7 +49,7 @@ namespace UnityEditor
 			}
 		}
 
-		protected static Texture2D[] s_AutoTransforms;
+		private static Texture2D[] s_AutoTransforms;
 		public static Texture2D[] autoTransforms
 		{
 			get
@@ -65,14 +65,14 @@ namespace UnityEditor
 			}
 		}
 		
-		protected ReorderableList m_ReorderableList;
+		private ReorderableList m_ReorderableList;
 		public RuleTile tile { get { return (target as RuleTile); } }
-		protected Rect m_ListRect;
+		private Rect m_ListRect;
 
-		protected const float k_DefaultElementHeight = 48f;
-		protected const float k_PaddingBetweenRules = 13f;
-		protected const float k_SingleLineHeight = 16f;
-		protected const float k_LabelWidth = 53f;
+		internal const float k_DefaultElementHeight = 48f;
+		internal const float k_PaddingBetweenRules = 13f;
+		internal const float k_SingleLineHeight = 16f;
+		internal const float k_LabelWidth = 53f;
 			
 		public void OnEnable()
 		{
@@ -87,12 +87,12 @@ namespace UnityEditor
 			m_ReorderableList.onAddCallback = OnAddElement;
 		}
 
-		protected void ListUpdated(ReorderableList list)
+		private void ListUpdated(ReorderableList list)
 		{
 			SaveTile();
 		}
 
-		protected float GetElementHeight(int index)
+		private float GetElementHeight(int index)
 		{
 			if (tile.m_TilingRules != null && tile.m_TilingRules.Count > 0)
 			{
@@ -107,7 +107,7 @@ namespace UnityEditor
 			return k_DefaultElementHeight + k_PaddingBetweenRules;
 		}
 
-		protected void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
+		private void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
 		{
 			RuleTile.TilingRule rule = tile.m_TilingRules[index];
 
@@ -136,13 +136,13 @@ namespace UnityEditor
 			tile.m_TilingRules.Add(rule);
 		}
 
-		protected void SaveTile()
+		private void SaveTile()
 		{
 			EditorUtility.SetDirty(target);
 			SceneView.RepaintAll();
 		}
 
-		protected void OnDrawHeader(Rect rect)
+		private void OnDrawHeader(Rect rect)
 		{
 			GUI.Label(rect, "Tiling Rules");
 		}
@@ -157,7 +157,7 @@ namespace UnityEditor
 				m_ReorderableList.DoLayoutList();
 		}
 
-		protected static void RuleMatrixOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+		internal static void RuleMatrixOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
 		{
 			Handles.color = EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.2f) : new Color(0f, 0f, 0f, 0.2f);
 			int index = 0;
@@ -230,13 +230,13 @@ namespace UnityEditor
 			}
 		}
 
-		protected static void OnSelect(object userdata)
+		private static void OnSelect(object userdata)
 		{
 			MenuItemData data = (MenuItemData) userdata;
 			data.m_Rule.m_RuleTransform = data.m_NewValue;
 		}
 
-		protected class MenuItemData
+		private class MenuItemData
 		{
 			public RuleTile.TilingRule m_Rule;
 			public RuleTile.TilingRule.Transform m_NewValue;
@@ -248,12 +248,12 @@ namespace UnityEditor
 			}
 		}
 
-		protected void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+		internal static void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
 		{
 			tilingRule.m_Sprites[0] = EditorGUI.ObjectField(new Rect(rect.xMax - rect.height, rect.yMin, rect.height, rect.height), tilingRule.m_Sprites[0], typeof (Sprite), false) as Sprite;
 		}
 
-		protected static void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+		internal static void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
 		{
 			float y = rect.yMin;
 			EditorGUI.BeginChangeCheck();
@@ -320,7 +320,7 @@ namespace UnityEditor
 			return base.RenderStaticPreview(assetPath, subAssets, width, height);
 		}
 
-		protected static Type GetType(string TypeName)
+		private static Type GetType(string TypeName)
 		{
 			var type = Type.GetType(TypeName);
 			if (type != null)
@@ -352,7 +352,7 @@ namespace UnityEditor
 			return null;
 		}
 
-		protected static Texture2D Base64ToTexture(string base64)
+		private static Texture2D Base64ToTexture(string base64)
 		{
 			Texture2D t = new Texture2D(1, 1);
 			t.hideFlags = HideFlags.HideAndDontSave;


### PR DESCRIPTION
Because the last pull request merge conflict and re-pull.

This solution can customize RuleTile without writing Editor code.
If you have any ideas welcome to join the discussion.
Issue: https://github.com/Unity-Technologies/2d-extras/issues/27

## Features
- Inheritable RuleTile
- Customizable attributes
- Can expand or rewrite neighbor rules and GUI display
- Can be used by RuleOverrideTile
- Template script (Menu: Assets/Create/Custom Rule Tile Script)
- Neighbor rules tooltip
- Backward compatible

## Usage
- Custom Attributes:
```csharp
public class MyTile : RuleTile {
	public string tileId;
	public bool isWater;
}
```

- Custom Rules:
```csharp
public class MyTile : RuleTile<MyTile.Neighbor> {
	public class Neighbor {
		public const int MyRule1 = 0;
		public const int MyRule2 = 1;
	}
	public override bool RuleMatch(int neighbor, TileBase tile) {
		switch (neighbor) {
			case Neighbor.MyRule1: return false;
			case Neighbor.MyRule2: return true;
		}
		return true;
	}
}
```

- Expansion Rules
```csharp
public class MyTile : RuleTile<MyTile.Neighbor> {
	public class Neighbor : RuleTile.TilingRule.Neighbor {
		// 0, 1, 2 is using in RuleTile.TilingRule.Neighbor
		public const int MyRule1 = 3;
		public const int MyRule2 = 4;
	}
	public override bool RuleMatch(int neighbor, TileBase tile) {
		switch (neighbor) {
			case Neighbor.MyRule1: return false;
			case Neighbor.MyRule2: return true;
		}
		return base.RuleMatch(neighbor, tile);
	}
}
```

- Siblings Tile 1
```csharp
public class MyTile : RuleTile<MyTile.Neighbor> {
	public List<TileBase> sibings = new List<TileBase>();
	public class Neighbor : RuleTile.TilingRule.Neighbor {
		public const int Sibing = 3;
	}
	public override bool RuleMatch(int neighbor, TileBase tile) {
		switch (neighbor) {
			case Neighbor.Sibing: return sibings.Contains(tile);
		}
		return base.RuleMatch(neighbor, tile);
	}
}
```

- Siblings Tile 2
```csharp
public class MyTile : RuleTile<MyTile.Neighbor> {
	public int siblingGroup;
	public class Neighbor : RuleTile.TilingRule.Neighbor {
		public const int Sibing = 3;
	}
	public override bool RuleMatch(int neighbor, TileBase tile) {
		MyTile myTile = tile as MyTile;
		switch (neighbor) {
			case Neighbor.Sibing: return myTile && myTile.siblingGroup == siblingGroup;
		}
		return base.RuleMatch(neighbor, tile);
	}
}
```