### PR TITLE
Added an option to choose Game Objects per rule in rule tiles

### DIFF
--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
@@ -40,9 +40,10 @@ namespace UnityEditor
 		private Rect m_ListRect;
 
 		internal const float k_DefaultElementHeight = 48f;
-		internal const float k_PaddingBetweenRules = 13f;
+		internal const float k_PaddingBetweenRules = 26f;
 		internal const float k_SingleLineHeight = 16f;
-		internal const float k_LabelWidth = 53f;
+		internal const float k_objectFieldLineHeight = 20f;
+        internal const float k_LabelWidth = 80f;
 			
 		public void OnEnable()
 		{
@@ -102,7 +103,8 @@ namespace UnityEditor
 			RuleTile.TilingRule rule = new RuleTile.TilingRule();
 			rule.m_Output = RuleTile.TilingRule.OutputSprite.Single;
 			rule.m_Sprites[0] = tile.m_DefaultSprite;
-			rule.m_ColliderType = tile.m_DefaultColliderType;
+			rule.m_GameObject = tile.m_DefaultGameObject;
+            rule.m_ColliderType = tile.m_DefaultColliderType;
 			tile.m_TilingRules.Add(rule);
 		}
 
@@ -120,7 +122,8 @@ namespace UnityEditor
 		public override void OnInspectorGUI()
 		{
 			tile.m_DefaultSprite = EditorGUILayout.ObjectField("Default Sprite", tile.m_DefaultSprite, typeof(Sprite), false) as Sprite;
-			tile.m_DefaultColliderType = (Tile.ColliderType)EditorGUILayout.EnumPopup("Default Collider", tile.m_DefaultColliderType);
+			tile.m_DefaultGameObject = EditorGUILayout.ObjectField("Default Game Object", tile.m_DefaultGameObject, typeof(GameObject), false) as GameObject;
+            tile.m_DefaultColliderType = (Tile.ColliderType)EditorGUILayout.EnumPopup("Default Collider", tile.m_DefaultColliderType);
 
 			var baseFields = typeof(RuleTile).GetFields().Select(field => field.Name);
 			var fields = target.GetType().GetFields().Select(field => field.Name).Where(field => !baseFields.Contains(field));
@@ -232,7 +235,10 @@ namespace UnityEditor
 		{
 			float y = rect.yMin;
 			EditorGUI.BeginChangeCheck();
-			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Rule");
+            GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Game Object");
+            tilingRule.m_GameObject = (GameObject)EditorGUI.ObjectField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), "", tilingRule.m_GameObject, typeof(GameObject), true);
+            y += k_objectFieldLineHeight;
+            GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Rule");
 			tilingRule.m_RuleTransform = (RuleTile.TilingRule.Transform)EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), tilingRule.m_RuleTransform);
 			y += k_SingleLineHeight;
 			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Collider");
@@ -241,8 +247,10 @@ namespace UnityEditor
 			GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Output");
 			tilingRule.m_Output = (RuleTile.TilingRule.OutputSprite)EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), tilingRule.m_Output);
 			y += k_SingleLineHeight;
+            
 
-			if (tilingRule.m_Output == RuleTile.TilingRule.OutputSprite.Animation)
+
+            if (tilingRule.m_Output == RuleTile.TilingRule.OutputSprite.Animation)
 			{
 				GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Speed");
 				tilingRule.m_AnimationSpeed = EditorGUI.FloatField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), tilingRule.m_AnimationSpeed);

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
@@ -42,7 +42,7 @@ namespace UnityEditor
 		internal const float k_DefaultElementHeight = 48f;
 		internal const float k_PaddingBetweenRules = 26f;
 		internal const float k_SingleLineHeight = 16f;
-		internal const float k_objectFieldLineHeight = 20f;
+		internal const float k_ObjectFieldLineHeight = 20f;
         internal const float k_LabelWidth = 80f;
 			
 		public void OnEnable()
@@ -237,7 +237,7 @@ namespace UnityEditor
 			EditorGUI.BeginChangeCheck();
             GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Game Object");
             tilingRule.m_GameObject = (GameObject)EditorGUI.ObjectField(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), "", tilingRule.m_GameObject, typeof(GameObject), true);
-            y += k_objectFieldLineHeight;
+            y += k_ObjectFieldLineHeight;
             GUI.Label(new Rect(rect.xMin, y, k_LabelWidth, k_SingleLineHeight), "Rule");
 			tilingRule.m_RuleTransform = (RuleTile.TilingRule.Transform)EditorGUI.EnumPopup(new Rect(rect.xMin + k_LabelWidth, y, rect.width - k_LabelWidth, k_SingleLineHeight), tilingRule.m_RuleTransform);
 			y += k_SingleLineHeight;

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
@@ -152,6 +152,7 @@ namespace UnityEngine
         {
             if (instantiateedGameObject != null)
             {
+                instantiateedGameObject.transform.position = location + new Vector3(0.5f,0.5f,0);
                 instantiateedGameObject.transform.rotation = m_GameObjectQuaternion;
             }
 

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
@@ -97,7 +97,8 @@ namespace UnityEngine
 		private static readonly int NeighborCount = 8;
 
 		public Sprite m_DefaultSprite;
-		public Tile.ColliderType m_DefaultColliderType = Tile.ColliderType.Sprite;
+		public GameObject m_DefaultGameObject;
+        public Tile.ColliderType m_DefaultColliderType = Tile.ColliderType.Sprite;
 		public TileBase m_Self
 		{
 			get { return m_OverrideSelf ? m_OverrideSelf : this; }
@@ -112,7 +113,8 @@ namespace UnityEngine
 		{
 			public int[] m_Neighbors;
 			public Sprite[] m_Sprites;
-			public float m_AnimationSpeed;
+			public GameObject m_GameObject;
+            public float m_AnimationSpeed;
 			public float m_PerlinScale;
 			public Transform m_RuleTransform;
 			public OutputSprite m_Output;
@@ -124,7 +126,8 @@ namespace UnityEngine
 				m_Output = OutputSprite.Single;
 				m_Neighbors = new int[NeighborCount];
 				m_Sprites = new Sprite[1];
-				m_AnimationSpeed = 1f;
+                m_GameObject = null;
+                m_AnimationSpeed = 1f;
 				m_PerlinScale = 0.5f;
 				m_ColliderType = Tile.ColliderType.Sprite;
 
@@ -151,7 +154,8 @@ namespace UnityEngine
 			var iden = Matrix4x4.identity;
 
 			tileData.sprite = m_DefaultSprite;
-			tileData.colliderType = m_DefaultColliderType;
+			tileData.gameObject = m_DefaultGameObject;
+            tileData.colliderType = m_DefaultColliderType;
 			tileData.flags = TileFlags.LockTransform;
 			tileData.transform = iden;
 
@@ -174,7 +178,8 @@ namespace UnityEngine
 							break;
 					}
 					tileData.transform = transform;
-					tileData.colliderType = rule.m_ColliderType;
+					tileData.gameObject = rule.m_GameObject;
+                    tileData.colliderType = rule.m_ColliderType;
 					break;
 				}
 			}

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
@@ -107,6 +107,7 @@ namespace UnityEngine
 
 		private TileBase[] m_CachedNeighboringTiles = new TileBase[NeighborCount];
 		private TileBase m_OverrideSelf;
+        private Quaternion m_GameObjectQuaternion;
 
 		[Serializable]
 		public class TilingRule
@@ -147,7 +148,17 @@ namespace UnityEngine
 
 		[HideInInspector] public List<TilingRule> m_TilingRules;
 
-		public override void GetTileData(Vector3Int position, ITilemap tilemap, ref TileData tileData)
+        public override bool StartUp(Vector3Int location, ITilemap tilemap, GameObject instantiateedGameObject)
+        {
+            if (instantiateedGameObject != null)
+            {
+                instantiateedGameObject.transform.rotation = m_GameObjectQuaternion;
+            }
+
+            return true;
+        }
+
+        public override void GetTileData(Vector3Int position, ITilemap tilemap, ref TileData tileData)
 		{
 			TileBase[] neighboringTiles = null;
 			GetMatchingNeighboringTiles(tilemap, position, ref neighboringTiles);
@@ -177,10 +188,13 @@ namespace UnityEngine
 								transform = ApplyRandomTransform(rule.m_RandomTransform, transform, rule.m_PerlinScale, position);
 							break;
 					}
-					tileData.transform = transform;
+                    tileData.transform = transform;
 					tileData.gameObject = rule.m_GameObject;
                     tileData.colliderType = rule.m_ColliderType;
-					break;
+
+                    // Converts the tile's rotation matrix to a quaternion to be used by the instantiated Game Object
+                    m_GameObjectQuaternion = Quaternion.LookRotation(new Vector3(transform.m02, transform.m12, transform.m22), new Vector3(transform.m01, transform.m11, transform.m21));
+                    break;
 				}
 			}
 		}
@@ -396,5 +410,5 @@ namespace UnityEngine
 		{
 			return new Vector3Int(original.x * (mirrorX ? -1 : 1), original.y * (mirrorY ? -1 : 1), original.z);
 		}
-	}
+    }
 }


### PR DESCRIPTION
Rule tiles are great. But not allowing you to specify a game object per rule is something that limits its power.
Hope this can help anyone trying to pull advanced stuff in combination with rule tiles. I know I needed this, and I hope this can help others too.