### PR TITLE
A simple fix for PrefabBrush to address the 'NullReferenceException' issue in 2018.3

### DIFF
--- a/Assets/Tilemap/Brushes/Prefab Brush/Scripts/Editor/PrefabBrush.cs
+++ b/Assets/Tilemap/Brushes/Prefab Brush/Scripts/Editor/PrefabBrush.cs
@@ -7,16 +7,22 @@ namespace UnityEditor
 {
     [CreateAssetMenu(fileName = "Prefab brush", menuName = "Brushes/Prefab brush")]
 	[CustomGridBrush(false, true, false, "Prefab Brush")]
-	public class PrefabBrush : GridBrushBase
+	public class PrefabBrush : GridBrush
 	{
 		private const float k_PerlinOffset = 100000f;
 		public GameObject[] m_Prefabs;
 		public float m_PerlinScale = 0.5f;
 		public int m_Z;
-		private prev_brushTarget;
+		private GameObject prev_brushTarget;
+		private Vector3Int prev_position;
 
 		public override void Paint(GridLayout grid, GameObject brushTarget, Vector3Int position)
 		{
+			if (position == prev_position)
+            		{
+                		return;
+            		}
+            		prev_position = position;
 			if (brushTarget) {
 				prev_brushTarget = brushTarget;
 			}
@@ -40,6 +46,11 @@ namespace UnityEditor
 
 		public override void Erase(GridLayout grid, GameObject brushTarget, Vector3Int position)
 		{
+			if (brushTarget)
+            		{
+                		prev_brushTarget = brushTarget;
+            		}
+            		brushTarget = prev_brushTarget;
 			// Do not allow editing palettes
 			if (brushTarget.layer == 31)
 				return;
@@ -72,7 +83,7 @@ namespace UnityEditor
 	}
 
 	[CustomEditor(typeof(PrefabBrush))]
-	public class PrefabBrushEditor : GridBrushEditorBase
+	public class PrefabBrushEditor : GridBrushEditor
 	{
 		private PrefabBrush prefabBrush { get { return target as PrefabBrush; } }
 
@@ -81,6 +92,7 @@ namespace UnityEditor
 
 		protected void OnEnable()
 		{
+			base.OnEnable();
 			m_SerializedObject = new SerializedObject(target);
 			m_Prefabs = m_SerializedObject.FindProperty("m_Prefabs");
 		}

--- a/Assets/Tilemap/Brushes/Prefab Brush/Scripts/Editor/PrefabBrush.cs
+++ b/Assets/Tilemap/Brushes/Prefab Brush/Scripts/Editor/PrefabBrush.cs
@@ -13,9 +13,15 @@ namespace UnityEditor
 		public GameObject[] m_Prefabs;
 		public float m_PerlinScale = 0.5f;
 		public int m_Z;
+		private prev_brushTarget;
 
 		public override void Paint(GridLayout grid, GameObject brushTarget, Vector3Int position)
 		{
+			if (brushTarget) {
+				prev_brushTarget = brushTarget;
+			}
+			brushTarget = prev_brushTarget;
+
 			// Do not allow editing palettes
 			if (brushTarget.layer == 31)
 				return;


### PR DESCRIPTION
PrefabBrush is broken in Unity 2018.3: after selecting the target tilemap, you can only draw one prefab onto it. Subsequent drawing gives a 'NullReferenceException' error. 
This problem has been reported at Unity Answers too:
https://answers.unity.com/questions/1571608/prefab-brush-from-2d-extras-not-working-in-tilemap.html