### PR TITLE
Updated PrefabBrush.cs Paint method for runtime 

### DIFF
--- a/Assets/Tilemap/Brushes/Prefab Brush/Scripts/Editor/PrefabBrush.cs
+++ b/Assets/Tilemap/Brushes/Prefab Brush/Scripts/Editor/PrefabBrush.cs
@@ -18,6 +18,8 @@ namespace UnityEditor
 
         public override void Paint(GridLayout grid, GameObject brushTarget, Vector3Int position)
         {
+            Transform itemInCell = GetObjectInCell(grid, brushTarget.transform, new Vector3Int(position.x, position.y, m_Z));
+            if (itemInCell != null) return;
             if (position == prev_position)
                     {
                         return;


### PR DESCRIPTION
Updated PrefabBrush.cs Paint method for runtime, solving the issue that if a prefab is painted before runtime it can have another painted ontop of it at runtime.