### PR TITLE
Pre-populate rule override tile based on sprite sheet

### DIFF
--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs
@@ -1,0 +1,82 @@
+﻿using UnityEngine;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace UnityEditor {
+	public class PopulateRuleOverideTileWizard : ScriptableWizard {
+
+		public Texture2D m_spriteSet;
+
+		private RuleOverrideTile m_tileset;
+
+		//[MenuItem("Assets/Generate Rule Tile Override")]
+		public static void CreateWizard(RuleOverrideTile target) {
+			PopulateRuleOverideTileWizard wizard = DisplayWizard<PopulateRuleOverideTileWizard>("Populate Override", "Populate");
+			wizard.m_tileset = target;
+		}
+
+		public static void CloneWizard(PopulateRuleOverideTileWizard oldWizard) {
+			PopulateRuleOverideTileWizard wizard = DisplayWizard<PopulateRuleOverideTileWizard>("Populate Override", "Populate");
+			wizard.m_tileset = oldWizard.m_tileset;
+			wizard.m_spriteSet = oldWizard.m_spriteSet;
+		}
+
+		private void OnWizardUpdate() {
+			isValid = m_tileset != null && m_spriteSet != null;
+
+		}
+
+		private void OnWizardCreate() {
+			try {
+				Populate();
+			}
+			catch(System.Exception ex) {
+				EditorUtility.DisplayDialog("Auto-populate failed!", ex.Message, "Ok");
+				CloneWizard(this);
+			}
+		}
+
+		/// <summary>
+		/// Attempts to populate the selected override tile using the chosen sprite.
+		/// The assumption here is that the sprite set selected by the user has the same
+		/// naming scheme as the original sprite. That is to say, they should both have the same number
+		/// of sprites, each sprite ends in an underscore followed by a number, and that they are
+		/// intended to be equivalent in function.
+		/// </summary>
+		///
+		private void Populate() {
+			string spriteSheet = AssetDatabase.GetAssetPath(m_spriteSet);
+			Sprite[] overrideSprites = AssetDatabase.LoadAllAssetsAtPath(spriteSheet).OfType<Sprite>().ToArray();
+
+			bool finished = false;
+
+			try {
+				Undo.RecordObject(m_tileset, "Auto-populate " + m_tileset.name);
+
+				foreach(RuleTile.TilingRule rule in m_tileset.m_Tile.m_TilingRules) {
+					foreach(Sprite originalSprite in rule.m_Sprites) {
+						string spriteName = originalSprite.name;
+						string spriteNumber = Regex.Match(spriteName, @"_\d+$").Value;
+
+						Sprite matchingOverrideSprite = overrideSprites.First(sprite => sprite.name.EndsWith(spriteNumber));
+
+						m_tileset[originalSprite] = matchingOverrideSprite;
+					}
+				}
+
+				finished = true;
+			}
+			catch(System.InvalidOperationException ex) {
+				throw (new System.ArgumentOutOfRangeException("Sprite sheet mismatch", ex));
+			}
+			finally {
+				// We handle the undo like this in case we end up catching more exceptions.
+				// We want this to ALWAYS happen unless we complete the population.
+				if(!finished) {
+					Undo.PerformUndo();
+				}
+			}
+		}
+
+	}
+}

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs
@@ -5,6 +5,18 @@ using System.Text.RegularExpressions;
 namespace UnityEditor {
 	public class PopulateRuleOverideTileWizard : ScriptableWizard {
 
+        [MenuItem("CONTEXT/RuleOverrideTile/Populate From Sprite Sheet")]
+        static void MenuOption(MenuCommand menuCommand)
+        {
+                PopulateRuleOverideTileWizard.CreateWizard(menuCommand.context as RuleOverrideTile);
+        }
+        [MenuItem("CONTEXT/RuleOverrideTile/Populate From Sprite Sheet", true)]
+        static bool MenuOptionValidation(MenuCommand menuCommand)
+        {
+                RuleOverrideTile tile = menuCommand.context as RuleOverrideTile;
+                return tile.m_Tile && !tile.m_Advanced;
+        }
+
 		public Texture2D m_spriteSet;
 
 		private RuleOverrideTile m_tileset;

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.Linq;
 using System.Text.RegularExpressions;
 

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs.meta
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/PopulateRuleOverrideTileWizard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dcb91d1bb7d18847b5ce74c4cdb1921
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
@@ -61,10 +61,22 @@ namespace UnityEditor
             EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Advanced"));
             serializedObject.ApplyModifiedProperties();
 
+
+			using(new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
+			{
+				if(GUILayout.Button("Populate based on sprite sheet..."))
+				{
+					foreach(UnityEngine.Object obj in serializedObject.targetObjects) {
+						PopulateRuleOverideTileWizard.CreateWizard(obj as RuleOverrideTile);
+					}
+				}
+			}
+
             if (!overrideTile.m_Advanced)
             {
                 using (new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
                 {
+
                     EditorGUI.BeginChangeCheck();
                     overrideTile.GetOverrides(m_Sprites);
 
@@ -90,6 +102,7 @@ namespace UnityEditor
                     m_RuleList.DoLayoutList();
                 }
             }
+
         }
 
         private void SaveTile()

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
@@ -61,22 +61,20 @@ namespace UnityEditor
             EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Advanced"));
             serializedObject.ApplyModifiedProperties();
 
-
-			using(new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
-			{
-				if(GUILayout.Button("Populate based on sprite sheet..."))
-				{
-					foreach(UnityEngine.Object obj in serializedObject.targetObjects) {
-						PopulateRuleOverideTileWizard.CreateWizard(obj as RuleOverrideTile);
-					}
-				}
-			}
+            using(new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
+            {
+                if(GUILayout.Button("Populate based on sprite sheet..."))
+                {
+                    foreach(UnityEngine.Object obj in serializedObject.targetObjects) {
+                        PopulateRuleOverideTileWizard.CreateWizard(obj as RuleOverrideTile);
+                    }
+                }
+            }
 
             if (!overrideTile.m_Advanced)
             {
                 using (new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
                 {
-
                     EditorGUI.BeginChangeCheck();
                     overrideTile.GetOverrides(m_Sprites);
 
@@ -102,7 +100,6 @@ namespace UnityEditor
                     m_RuleList.DoLayoutList();
                 }
             }
-
         }
 
         private void SaveTile()

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
@@ -61,16 +61,6 @@ namespace UnityEditor
             EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Advanced"));
             serializedObject.ApplyModifiedProperties();
 
-            using(new EditorGUI.DisabledScope(overrideTile.m_Tile == null))
-            {
-                if(GUILayout.Button("Populate based on sprite sheet..."))
-                {
-                    foreach(UnityEngine.Object obj in serializedObject.targetObjects) {
-                        PopulateRuleOverideTileWizard.CreateWizard(obj as RuleOverrideTile);
-                    }
-                }
-            }
-
             if (!overrideTile.m_Advanced)
             {
                 using (new EditorGUI.DisabledScope(overrideTile.m_Tile == null))


### PR DESCRIPTION
I've created a bare-bones wizard that makes it easy to create override tiles based on identical tile-sheets. I made it because I needed an easy way to create rule override tile sets based on a template. Otherwise, I would need to set 30+ overrides, one by one, whenever I created a new tile set.

It does have a few glaring limitations/issues that should probably be resolved before merging this into the main build. Sadly, I probably won't be the one making these fixes; it fulfills my needs as-is. However, I'm creating the PR in hopes that someone else might find this useful.

### Problems
- It cares about the naming schemes of individual sprites. (It searches for the underscore followed by a number. For example, Template<em><b>_23</b></em> is matched against River<em><b>_23</b></em>. Whatever comes before the underscore is ignored.) In other words, **if both sprite sheets have the same number of tiles _and_ their names have not been changed, it should work fine.**
- A more polished interface would probably allow you to **spawn new rule override tiles from existing rule tiles**, rather than needing to create the rule override tile and then click a button in its inspector view.
- When it populates, **it's rather inefficient and will chug on very large tilesets**. (Runs in _O(n*m)_ time, AFAIK.) This could probably be fixed by using a hash-data structure.
- **There are _probably_ some edge cases which could cause it to die horribly.** (For example, I haven't tried opening the wizard, deleting the rule override tile, and then making it populate the now deleted tile.)
- **It's very possible I've violated some stylistic rule.**
- ~~**Line endings in RuleOverrideTileEditor got botched.** I blame Visual Studio.~~ Never mind, it's been fixed.

### Pictures
<details>
 <summary><b>These are my tile sheets. The first is my template (which is not meant as part of the game; just a means of testing the rules), and the second is one of my many tile sheets. The template has already been set up as a rule tile, while the river tile is going to become a river tile.</b></summary>

  ---

![Template](https://user-images.githubusercontent.com/7464159/57153346-e8ca5780-6d8a-11e9-87da-d47aa74a28f7.png)

![River](https://user-images.githubusercontent.com/7464159/57153347-e8ca5780-6d8a-11e9-9316-ad9aad6b383b.png)

  ---
<p>
<em>(Note that I cannot just use the terrain tile because I do not want these tiles being flipped vertically.)</em>
</p>
</details>

<details>
 <summary><b>After creating a rule override tile (and setting it to override the template), the inspector looks like this. Note that the "Populate" button is disabled unless there is currently a tile being overridden.</b></summary>

  ---

![Selection](https://user-images.githubusercontent.com/7464159/57153337-dfd98600-6d8a-11e9-82c9-7077f55188c1.png)

  ---
</details>


<details>
 <summary><b>This is the wizard. There is some error checking here; if you give it an invalid Texture2D (i.e. an exception gets thrown while populating), a error dialog is shown and the wizard is reopened.</b></summary>

  ---

![Wizard](https://user-images.githubusercontent.com/7464159/57153338-e0721c80-6d8a-11e9-8b81-c7ed69d68c50.png)

  ---
</details>

<details>
 <summary><b>And this is what it looks like after populating.</b></summary>

  ---

![EndResult](https://user-images.githubusercontent.com/7464159/57153335-dfd98600-6d8a-11e9-87e5-ba83b898bf12.png)

  ---
</details>