### PR TITLE
Fix RuleOverrideTile update timing

### DIFF
--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/Editor/RuleOverrideTileEditor.cs
@@ -56,10 +56,15 @@ namespace UnityEditor
         {
             serializedObject.UpdateIfRequiredOrScript();
 
+            EditorGUI.BeginChangeCheck();
+
             EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Tile"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("m_OverrideSelf"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Advanced"));
             serializedObject.ApplyModifiedProperties();
+
+            if (EditorGUI.EndChangeCheck())
+                SaveTile();
 
             if (!overrideTile.m_Advanced)
             {
@@ -96,6 +101,8 @@ namespace UnityEditor
         {
             EditorUtility.SetDirty(target);
             SceneView.RepaintAll();
+
+            overrideTile.Override();
         }
 
         private void DrawSpriteElement(Rect rect, int index, bool selected, bool focused)
@@ -309,8 +316,6 @@ namespace UnityEditor
         }
         private void DrawRuleHeader(Rect rect)
         {
-            overrideTile.Override();
-
             float matrixWidth = k_DefaultElementHeight;
 
             float xMax = rect.xMax;

--- a/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Override Tile/Scripts/RuleOverrideTile.cs
@@ -119,31 +119,33 @@ namespace UnityEngine
                 };
             }
         }
+        public RuleTile runtimeTile
+        {
+            get
+            {
+                if (!m_RuntimeTile)
+                    Override();
+                return m_RuntimeTile;
+            }
+        }
 
-        [HideInInspector] public RuleTile m_RuntimeTile;
+        private RuleTile m_RuntimeTile;
 
         public override bool GetTileAnimationData(Vector3Int position, ITilemap tilemap, ref TileAnimationData tileAnimationData)
         {
-            if (!m_RuntimeTile)
-                Override();
-            return m_RuntimeTile.GetTileAnimationData(position, tilemap, ref tileAnimationData);
+            return runtimeTile.GetTileAnimationData(position, tilemap, ref tileAnimationData);
         }
         public override void GetTileData(Vector3Int position, ITilemap tilemap, ref TileData tileData)
         {
-            if (!m_RuntimeTile)
-                Override();
-            m_RuntimeTile.GetTileData(position, tilemap, ref tileData);
+            runtimeTile.GetTileData(position, tilemap, ref tileData);
         }
         public override void RefreshTile(Vector3Int position, ITilemap tilemap)
         {
-            if (!m_RuntimeTile)
-                Override();
-            m_RuntimeTile.RefreshTile(position, tilemap);
+            runtimeTile.RefreshTile(position, tilemap);
         }
         public override bool StartUp(Vector3Int position, ITilemap tilemap, GameObject go)
         {
-            Override();
-            return m_RuntimeTile.StartUp(position, tilemap, go);
+            return runtimeTile.StartUp(position, tilemap, go);
         }
 
         public void ApplyOverrides(IList<KeyValuePair<Sprite, Sprite>> overrides)
@@ -224,7 +226,8 @@ namespace UnityEngine
                     m_RuntimeTile.m_DefaultSprite = m_OverrideDefault.m_TilingRule.m_Sprites.Length > 0 ? m_OverrideDefault.m_TilingRule.m_Sprites[0] : null;
                     m_RuntimeTile.m_DefaultColliderType = m_OverrideDefault.m_TilingRule.m_ColliderType;
                 }
-                if (m_RuntimeTile.m_TilingRules != null) {
+                if (m_RuntimeTile.m_TilingRules != null)
+                {
                     for (int i = 0; i < m_RuntimeTile.m_TilingRules.Count; i++)
                     {
                         RuleTile.TilingRule originalRule = m_RuntimeTile.m_TilingRules[i];

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/Editor/RuleTileEditor.cs
@@ -139,6 +139,20 @@ namespace UnityEditor
         {
             EditorUtility.SetDirty(target);
             SceneView.RepaintAll();
+
+            UpdateOverrideTiles();
+        }
+
+        private void UpdateOverrideTiles()
+        {
+            string[] overrideTileGuids = AssetDatabase.FindAssets("t:RuleOverrideTile");
+            foreach (string overrideTileGuid in overrideTileGuids)
+            {
+                string overrideTilePath = AssetDatabase.GUIDToAssetPath(overrideTileGuid);
+                RuleOverrideTile overrideTile = AssetDatabase.LoadAssetAtPath<RuleOverrideTile>(overrideTilePath);
+                if (overrideTile.m_Tile == target)
+                    overrideTile.Override();
+            }
         }
 
         private void OnDrawHeader(Rect rect)

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
@@ -225,6 +225,11 @@ namespace UnityEngine
 
         public virtual bool RuleMatch(int neighbor, TileBase tile)
         {
+            if (tile is RuleOverrideTile)
+                tile = (tile as RuleOverrideTile).runtimeTile.m_Self;
+            else if (tile is RuleTile)
+                tile = (tile as RuleTile).m_Self;
+
             switch (neighbor)
             {
                 case TilingRule.Neighbor.This: return tile == m_Self;
@@ -239,8 +244,6 @@ namespace UnityEngine
             {
                 int index = GetRotatedIndex(i, angle);
                 TileBase tile = neighboringTiles[index];
-                if (tile is RuleOverrideTile)
-                    tile = (tile as RuleOverrideTile).m_RuntimeTile.m_Self;
                 if (!RuleMatch(rule.m_Neighbors[i], tile))
                 {
                     return false;
@@ -255,8 +258,6 @@ namespace UnityEngine
             {
                 int index = GetMirroredIndex(i, mirrorX, mirrorY);
                 TileBase tile = neighboringTiles[index];
-                if (tile is RuleOverrideTile)
-                    tile = (tile as RuleOverrideTile).m_RuntimeTile.m_Self;
                 if (!RuleMatch(rule.m_Neighbors[i], tile))
                 {
                     return false;


### PR DESCRIPTION
Fix issue: https://github.com/Unity-Technologies/2d-extras/issues/100

In the past, RuleOverrideTile was refreshed when calling StartUp(), but since GetTileData() will be called earlier than StartUp(), there is no guarantee that the data will be correct in the StartUp() refresh.

The RuleOverrideTile will now be refreshed the first time data is requested. And update at the same time when the source tile is updated.