### PR TITLE
Fix problem with game object placing, when grid cell size is other th…

### DIFF
--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
@@ -87,7 +87,7 @@ namespace UnityEngine
             if (instantiateedGameObject != null)
             {
                 Tilemap tmpMap = tilemap.GetComponent<Tilemap>();
-                instantiateedGameObject.transform.position = tmpMap.CellToWorld(location) + Vector3.Scale(tmpMap.tileAnchor, tmpMap.cellSize);
+                instantiateedGameObject.transform.position = tmpMap.LocalToWorld(tmpMap.CellToLocalInterpolated(location + tmpMap.tileAnchor));
                 instantiateedGameObject.transform.rotation = m_GameObjectQuaternion;
             }
 

--- a/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
+++ b/Assets/Tilemap/Tiles/Rule Tile/Scripts/RuleTile.cs
@@ -86,7 +86,8 @@ namespace UnityEngine
         {
             if (instantiateedGameObject != null)
             {
-                instantiateedGameObject.transform.position = location + tilemap.GetComponent<Tilemap>().tileAnchor;
+                Tilemap tmpMap = tilemap.GetComponent<Tilemap>();
+                instantiateedGameObject.transform.position = tmpMap.CellToWorld(location) + Vector3.Scale(tmpMap.tileAnchor, tmpMap.cellSize);
                 instantiateedGameObject.transform.rotation = m_GameObjectQuaternion;
             }
 


### PR DESCRIPTION
When the size of the grid is different from 1, game objects are not placed on the tile, but at some distance. The proposed solution fixes this problem.