### PR TITLE
Coordinate Brush correctly using Tile Palette's Z Position field.

### DIFF
--- a/Assets/Tilemap/Brushes/Coordinate Brush/Scripts/Editor/CoordinateBrush.cs
+++ b/Assets/Tilemap/Brushes/Coordinate Brush/Scripts/Editor/CoordinateBrush.cs
@@ -7,29 +7,28 @@ namespace UnityEditor
     [CustomGridBrush(true, false, false, "Coordinate Brush")]
     [CreateAssetMenu(fileName = "New Coordinate Brush", menuName = "Brushes/Coordinate Brush")]
     public class CoordinateBrush : GridBrush {
-        public int z = 0;
 
         public override void Paint(GridLayout grid, GameObject brushTarget, Vector3Int position)
         {
-            var zPosition = new Vector3Int(position.x, position.y, z);
+            var zPosition = new Vector3Int(position.x, position.y, position.z);
             base.Paint(grid, brushTarget, zPosition);
         }
         
         public override void Erase(GridLayout grid, GameObject brushTarget, Vector3Int position)
         {
-            var zPosition = new Vector3Int(position.x, position.y, z);
+            var zPosition = new Vector3Int(position.x, position.y, position.z);
             base.Erase(grid, brushTarget, zPosition);
         }
         
         public override void FloodFill(GridLayout grid, GameObject brushTarget, Vector3Int position)
         {
-            var zPosition = new Vector3Int(position.x, position.y, z);
+            var zPosition = new Vector3Int(position.x, position.y, position.z);
             base.FloodFill(grid, brushTarget, zPosition);
         }
 
         public override void BoxFill(GridLayout gridLayout, GameObject brushTarget, BoundsInt position)
         {
-            var zPosition = new Vector3Int(position.x, position.y, z);
+            var zPosition = new Vector3Int(position.x, position.y, position.z);
             position.position = zPosition;
             base.BoxFill(gridLayout, brushTarget, position);
         }
@@ -42,16 +41,16 @@ namespace UnityEditor
 
         public override void PaintPreview(GridLayout grid, GameObject brushTarget, Vector3Int position)
         {
-            var zPosition = new Vector3Int(position.x, position.y, coordinateBrush.z);
+            var zPosition = new Vector3Int(position.x, position.y, position.z);
             base.PaintPreview(grid, brushTarget, zPosition);
         }
 
         public override void OnPaintSceneGUI(GridLayout grid, GameObject brushTarget, BoundsInt position, GridBrushBase.Tool tool, bool executing)
         {
             base.OnPaintSceneGUI(grid, brushTarget, position, tool, executing);
-            if (coordinateBrush.z != 0)
+            if (position.z != 0)
             {
-                var zPosition = new Vector3Int(position.min.x, position.min.y, coordinateBrush.z);
+                var zPosition = new Vector3Int(position.min.x, position.min.y, position.min.z);
                 BoundsInt newPosition = new BoundsInt(zPosition, position.size);
                 Vector3[] cellLocals = new Vector3[]
                 {
@@ -69,12 +68,12 @@ namespace UnityEditor
                 }
             }
 
-            var labelText = "Pos: " + new Vector3Int(position.x, position.y, coordinateBrush.z);
+            var labelText = "Pos: " + new Vector3Int(position.x, position.y, position.z);
             if (position.size.x > 1 || position.size.y > 1) {
                 labelText += " Size: " + new Vector2Int(position.size.x, position.size.y);
             }
 
-            Handles.Label(grid.CellToWorld(new Vector3Int(position.x, position.y, coordinateBrush.z)), labelText);
+            Handles.Label(grid.CellToWorld(new Vector3Int(position.x, position.y, position.z)), labelText);
         }
     }
 }


### PR DESCRIPTION
Fix for #112 

Minimally removed the z integer in the CoordinateBrush class. The coordinate brush now correctly uses the Tile Palette's Z Position field like other brushes.