### PR TITLE
[Destructive change] Unified RuleTile and RuleOverrideTile match rule

### DIFF
--- a/Editor/Tiles/RuleTile/RuleTileEditor.cs
+++ b/Editor/Tiles/RuleTile/RuleTileEditor.cs
@@ -74,9 +74,6 @@ namespace UnityEditor
 
         public void OnEnable()
         {
-            if (tile.m_TilingRules == null)
-                tile.m_TilingRules = new List<RuleTile.TilingRule>();
-
             m_ReorderableList = new ReorderableList(tile.m_TilingRules, typeof(RuleTile.TilingRule), true, true, true, true);
             m_ReorderableList.drawHeaderCallback = OnDrawHeader;
             m_ReorderableList.drawElementCallback = OnDrawElement;
@@ -171,10 +168,7 @@ namespace UnityEditor
 
             serializedObject.Update();
             EditorGUI.BeginChangeCheck();
-            var baseFields = typeof(RuleTile).GetFields().Select(field => field.Name);
-            var fields = target.GetType().GetFields().Select(field => field.Name).Where(field => !baseFields.Contains(field));
-            foreach (var field in fields)
-                EditorGUILayout.PropertyField(serializedObject.FindProperty(field), true);
+            DrawCustomFields(tile, serializedObject);
             if (EditorGUI.EndChangeCheck())
                 serializedObject.ApplyModifiedProperties();
 
@@ -182,6 +176,14 @@ namespace UnityEditor
 
             if (m_ReorderableList != null && tile.m_TilingRules != null)
                 m_ReorderableList.DoLayoutList();
+        }
+
+        public static void DrawCustomFields(Object tile, SerializedObject serializedObject)
+        {
+            var baseFields = typeof(RuleTile).GetFields().Select(field => field.Name);
+            var fields = tile.GetType().GetFields().Select(field => field.Name).Where(field => !baseFields.Contains(field));
+            foreach (var field in fields)
+                EditorGUILayout.PropertyField(serializedObject.FindProperty(field), true);
         }
 
         internal virtual void RuleOnGUI(Rect rect, int arrowIndex, int neighbor)

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -59,20 +59,11 @@ namespace UnityEngine
         /// The Default Collider Type set when creating a new Rule.
         /// </summary>
         public Tile.ColliderType m_DefaultColliderType = Tile.ColliderType.Sprite;
-        /// <summary>
-        /// Returns the instance of this Tile when matching Rules.
-        /// </summary>
-        public TileBase m_Self
-        {
-            get { return m_OverrideSelf ? m_OverrideSelf : this; }
-            set { m_OverrideSelf = value; }
-        }
 
         /// <summary>
         /// A cache for the neighboring Tiles when matching Rules.
         /// </summary>
         protected TileBase[] m_CachedNeighboringTiles = new TileBase[NeighborCount];
-        private TileBase m_OverrideSelf;
         private Quaternion m_GameObjectQuaternion;
 
         /// <summary>
@@ -203,7 +194,7 @@ namespace UnityEngine
         /// <summary>
         /// A list of Tiling Rules for the Rule Tile.
         /// </summary>
-        [HideInInspector] public List<TilingRule> m_TilingRules;
+        [HideInInspector] public List<TilingRule> m_TilingRules = new List<RuleTile.TilingRule>();
 
         /// <summary>
         /// StartUp is called on the first frame of the running Scene.
@@ -403,14 +394,12 @@ namespace UnityEngine
         public virtual bool RuleMatch(int neighbor, TileBase tile)
         {
             if (tile is RuleOverrideTile)
-                tile = (tile as RuleOverrideTile).runtimeTile.m_Self;
-            else if (tile is RuleTile)
-                tile = (tile as RuleTile).m_Self;
+                tile = (tile as RuleOverrideTile).m_InstanceTile;
 
             switch (neighbor)
             {
-                case TilingRule.Neighbor.This: return tile == m_Self;
-                case TilingRule.Neighbor.NotThis: return tile != m_Self;
+                case TilingRule.Neighbor.This: return tile == this;
+                case TilingRule.Neighbor.NotThis: return tile != this;
             }
             return true;
         }


### PR DESCRIPTION
### Changes
- [RuleTile] Roll back ```m_Self``` to ```this```.
- [RuleOverrideTile] Remove ```m_OverrideSelf``` property.
- [RuleOverrideTile] Inherit custom properties from custom RuleTile.

### Explanation
RuleOverrideTile can retain the custom properties of RuleTile. RuleOverride and RuleTile determine the connection in the same way, no longer limited to ```m_OverrideSelf``` to decide whether to connect with itself.
RuleTile no longer requires the ```m_Self``` attribute, which reduces code complexity.