### PR TITLE
Support unlimited rule size

### DIFF
--- a/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
+++ b/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using System.Reflection;
 using UnityEngine;
 
 namespace UnityEditor
@@ -8,41 +6,117 @@ namespace UnityEditor
     [CanEditMultipleObjects]
     public class HexagonalRuleTileEditor : RuleTileEditor
     {
-        private static readonly Vector2[] s_PointedTopPositions =
-        {
-            new Vector2(2f, 1f), new Vector2(1.5f, 2f), new Vector2(0.5f, 2f), new Vector2(0f, 1f), new Vector2(0.5f, 0f), new Vector2(1.5f, 0f)
-        };
-        private static readonly int[] s_PointedTopArrows = {5, 8, 6, 3, 0, 2};
-        private static readonly Vector2[] s_FlatTopPositions =
-        {
-            new Vector2(1f, 0f), new Vector2(2f, 0.5f), new Vector2(2f, 1.5f), new Vector2(1f, 2f), new Vector2(0f, 1.5f), new Vector2(0f, 0.5f)
-        };
-        private static readonly int[] s_FlatTopArrows = {1, 2, 8, 7, 6, 0};
 
-        internal override void RuleMatrixOnGUI(RuleTile ruleTile, Rect rect, RuleTile.TilingRule tilingRule)
+        public override int GetArrowIndex(Vector3Int position)
         {
-            var hexTile = (HexagonalRuleTile) ruleTile;
+            var hexTile = tile as HexagonalRuleTile;
+
+            if (position.y % 2 != 0)
+            {
+                position *= 2;
+                position.x += 1;
+            }
+
+            if (position.x == 0)
+            {
+                if (position.y > 0)
+                    return hexTile.m_FlatTop ? 3 : 1;
+                else
+                    return hexTile.m_FlatTop ? 5 : 7;
+            }
+            else if (position.y == 0)
+            {
+                if (position.x > 0)
+                    return hexTile.m_FlatTop ? 1 : 5;
+                else
+                    return hexTile.m_FlatTop ? 7 : 3;
+            }
+            else
+            {
+                if (position.x < 0 && position.y > 0)
+                    return hexTile.m_FlatTop ? 6 : 0;
+                else if (position.x > 0 && position.y > 0)
+                    return hexTile.m_FlatTop ? 0 : 2;
+                else if (position.x < 0 && position.y < 0)
+                    return hexTile.m_FlatTop ? 8 : 6;
+                else if (position.x > 0 && position.y < 0)
+                    return hexTile.m_FlatTop ? 2 : 8;
+            }
+
+            return -1;
+        }
+
+        public override BoundsInt GetRuleGUIBounds(RuleTile.TilingRule rule)
+        {
+            BoundsInt bounds = rule.bounds;
+            foreach (var n in rule.GetNeighbors())
+            {
+                if (n.Key.x == bounds.xMax - 1 && n.Key.y % 2 != 0)
+                {
+                    bounds.xMax++;
+                    break;
+                }
+            }
+            if (extendNeighbor)
+            {
+                bounds.xMin--;
+                bounds.yMin--;
+                bounds.xMax++;
+                bounds.yMax++;
+            }
+            bounds.xMin = Mathf.Min(bounds.xMin, -1);
+            bounds.yMin = Mathf.Min(bounds.yMin, -1);
+            bounds.xMax = Mathf.Max(bounds.xMax, 2);
+            bounds.yMax = Mathf.Max(bounds.yMax, 2);
+            return bounds;
+        }
+
+        protected override Vector2 GetMatrixSize(BoundsInt bounds)
+        {
+            var hexTile = tile as HexagonalRuleTile;
+            Vector2 size = base.GetMatrixSize(bounds);
+
+            if (hexTile.m_FlatTop)
+            {
+                float x = size.x;
+                float y = size.y;
+                size.x = y;
+                size.y = x;
+            }
+
+            return size;
+        }
+
+        public override void RuleMatrixOnGUI(RuleTile tile, Rect rect, BoundsInt bounds, RuleTile.TilingRule tilingRule)
+        {
+            var hexTile = tile as HexagonalRuleTile;
             bool flatTop = hexTile.m_FlatTop;
 
             Handles.color = EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.2f) : new Color(0f, 0f, 0f, 0.2f);
-            float w = rect.width / 3f;
-            float h = rect.height / 3f;
-            
+            float w = rect.width / (flatTop ? bounds.size.y : bounds.size.x);
+            float h = rect.height / (flatTop ? bounds.size.x : bounds.size.y);
+
             // Grid
             if (flatTop)
             {
-                for (int x = 0; x <= 3; x++)
+                for (int y = 0; y <= bounds.size.y; y++)
                 {
-                    float left = rect.xMin + x * w;
-                    float offset = x % 3 > 0 ? 0 : h / 2;
+                    float left = rect.xMin + y * w;
+                    float offset = 0;
+
+                    if (y == 0 && bounds.yMax % 2 == 0)
+                        offset = h / 2;
+                    else if (y == bounds.size.y && bounds.yMin % 2 != 0)
+                        offset = h / 2;
+
                     Handles.DrawLine(new Vector3(left, rect.yMin + offset), new Vector3(left, rect.yMax - offset));
 
-                    if (x < 3)
+                    if (y < bounds.size.y)
                     {
-                        bool noOffset = x % 2 > 0;
-                        for (int y = 0; y < (noOffset ? 4 : 3); y++)
+                        bool noOffset = (y + bounds.yMax) % 2 != 0;
+                        for (int x = 0; x < (noOffset ? (bounds.size.x + 1) : bounds.size.x); x++)
                         {
-                            float top = rect.yMin + y * h + (noOffset ? 0 : h / 2);
+                            float top = rect.yMin + x * h + (noOffset ? 0 : h / 2);
                             Handles.DrawLine(new Vector3(left, top), new Vector3(left + w, top));
                         }
                     }
@@ -50,16 +124,22 @@ namespace UnityEditor
             }
             else
             {
-                for (int y = 0; y <= 3; y++)
+                for (int y = 0; y <= bounds.size.y; y++)
                 {
                     float top = rect.yMin + y * h;
-                    float offset = y % 3 > 0 ? 0 : w / 2;
+                    float offset = 0;
+
+                    if (y == 0 && bounds.yMax % 2 == 0)
+                        offset = w / 2;
+                    else if (y == bounds.size.y && bounds.yMin % 2 != 0)
+                        offset = w / 2;
+
                     Handles.DrawLine(new Vector3(rect.xMin + offset, top), new Vector3(rect.xMax - offset, top));
 
-                    if (y < 3)
+                    if (y < bounds.size.y)
                     {
-                        bool noOffset = y % 2 > 0;
-                        for (int x = 0; x < (noOffset ? 4 : 3); x++)
+                        bool noOffset = (y + bounds.yMax) % 2 != 0;
+                        for (int x = 0; x < (noOffset ? (bounds.size.x + 1) : bounds.size.x); x++)
                         {
                             float left = rect.xMin + x * w + (noOffset ? 0 : w / 2);
                             Handles.DrawLine(new Vector3(left, top), new Vector3(left, top + h));
@@ -67,22 +147,55 @@ namespace UnityEditor
                     }
                 }
             }
-            
+
+            var neighbors = tilingRule.GetNeighbors();
+
             // Icons
             Handles.color = Color.white;
-            for (int index = 0; index < hexTile.neighborCount; ++index)
+            for (int y = bounds.yMin; y < bounds.yMax; y++)
             {
-                Vector2 position = flatTop ? s_FlatTopPositions[index] : s_PointedTopPositions[index];
-                int arrowIndex = flatTop ? s_FlatTopArrows[index] : s_PointedTopArrows[index];
-                Rect r = new Rect(rect.xMin + position.x * w, rect.yMin + position.y * h, w - 1, h - 1);
-                RuleOnGUI(r, arrowIndex, tilingRule.m_Neighbors[index]);
-                RuleNeighborUpdate(r, tilingRule, index);
-            }
-            // Center
-            {
-                Rect r = new Rect(rect.xMin + w, rect.yMin + h, w - 1, h - 1);
-                RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
-                RuleTransformUpdate(r, tilingRule);
+                int xMax = y % 2 == 0 ? bounds.xMax : (bounds.xMax - 1);
+                for (int x = bounds.xMin; x < xMax; x++)
+                {
+                    Vector3Int pos = new Vector3Int(x, y, 0);
+                    Vector2 offset = new Vector2(x - bounds.xMin, -y + bounds.yMax - 1);
+                    Rect r;
+
+                    if (flatTop)
+                        r = new Rect(rect.xMin + offset.y * w, rect.yMax - offset.x * h - h, w - 1, h - 1);
+                    else
+                        r = new Rect(rect.xMin + offset.x * w, rect.yMin + offset.y * h, w - 1, h - 1);
+
+                    if (y % 2 != 0)
+                    {
+                        if (flatTop)
+                            r.y -= h / 2;
+                        else
+                            r.x += w / 2;
+                    }
+
+                    if (x != 0 || y != 0)
+                    {
+                        if (neighbors.ContainsKey(pos))
+                        {
+                            RuleOnGUI(r, pos, neighbors[pos]);
+                            RuleTooltipOnGUI(r, neighbors[pos]);
+                        }
+                        if (RuleNeighborUpdate(r, tilingRule, neighbors, pos))
+                        {
+                            tile.UpdateRemoteRulePositions();
+                        }
+                    }
+                    else
+                    {
+                        // Center
+                        RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
+                        if (RuleTransformUpdate(r, tilingRule))
+                        {
+                            tile.UpdateRemoteRulePositions();
+                        }
+                    }
+                }
             }
         }
     }

--- a/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
+++ b/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
@@ -46,9 +46,8 @@ namespace UnityEditor
             return -1;
         }
 
-        public override BoundsInt GetRuleGUIBounds(RuleTile.TilingRule rule)
+        public override BoundsInt GetRuleGUIBounds(BoundsInt bounds, RuleTile.TilingRule rule)
         {
-            BoundsInt bounds = rule.bounds;
             foreach (var n in rule.GetNeighbors())
             {
                 if (n.Key.x == bounds.xMax - 1 && n.Key.y % 2 != 0)
@@ -71,7 +70,7 @@ namespace UnityEditor
             return bounds;
         }
 
-        protected override Vector2 GetMatrixSize(BoundsInt bounds)
+        public override Vector2 GetMatrixSize(BoundsInt bounds)
         {
             var hexTile = tile as HexagonalRuleTile;
             Vector2 size = base.GetMatrixSize(bounds);

--- a/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
+++ b/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
@@ -14,7 +14,7 @@ namespace UnityEditor
             return s_Arrows[base.GetArrowIndex(position)];
         }
 
-        protected override Vector2 GetMatrixSize(BoundsInt bounds)
+        public override Vector2 GetMatrixSize(BoundsInt bounds)
         {
             float p = Mathf.Pow(2, 0.5f);
             float w = (bounds.size.x / p + bounds.size.y / p) * k_SingleLineHeight;

--- a/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
+++ b/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UnityEditor
 {
@@ -9,65 +6,98 @@ namespace UnityEditor
     [CanEditMultipleObjects]
     public class IsometricRuleTileEditor : RuleTileEditor
     {
-        private static readonly int[, ] s_Arrows =
-        {
-            { 3, 0, 1 },
-            { 6, 9, 2 },
-            { 7, 8, 5 },
-        };
 
-        internal override void RuleMatrixOnGUI(RuleTile ruleTile, Rect rect, RuleTile.TilingRule tilingRule)
+        private static readonly int[] s_Arrows = { 7, 8, 5, 6, -1, 2, 3, 0, 1 };
+
+        public override int GetArrowIndex(Vector3Int position)
+        {
+            return s_Arrows[base.GetArrowIndex(position)];
+        }
+
+        protected override Vector2 GetMatrixSize(BoundsInt bounds)
+        {
+            float p = Mathf.Pow(2, 0.5f);
+            float w = (bounds.size.x / p + bounds.size.y / p) * k_SingleLineHeight;
+            return new Vector2(w, w);
+        }
+
+        public override void RuleMatrixOnGUI(RuleTile ruleTile, Rect rect, BoundsInt bounds, RuleTile.TilingRule tilingRule)
         {
             Handles.color = EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.2f) : new Color(0f, 0f, 0f, 0.2f);
-            int index = 0;
-            float w = rect.width / 3f;
-            float h = rect.height / 3f;
-            
+            float w = rect.width / bounds.size.x;
+            float h = rect.height / bounds.size.y;
+
             // Grid
-            for (int y = 0; y <= 3; y++)
+            float d = rect.width / (bounds.size.x + bounds.size.y);
+            for (int y = 0; y <= bounds.size.y; y++)
             {
-                float left = rect.xMin + (y * rect.width) / 6;
-                float right = left + rect.width / 2;
-                float bottom = rect.yMin + (y * rect.height) / 6;
-                float top = bottom + rect.height / 2;
-                Handles.DrawLine(new Vector3(left, top), new Vector3(right, bottom));
+                float left = rect.xMin + d * y;
+                float right = rect.xMax - d * (bounds.size.y - y);
+                float top = rect.yMin + d * y;
+                float bottom = rect.yMax - d * (bounds.size.y - y);
+                Handles.DrawLine(new Vector3(left, bottom), new Vector3(right, top));
             }
-            for (int x = 0; x <= 3; x++)
+            for (int x = 0; x <= bounds.size.x; x++)
             {
-                float left = rect.xMin + (x * rect.width) / 6;
-                float right = left + rect.width / 2;
-                float top = rect.yMax - (x * rect.height) / 6;
-                float bottom = top - rect.height / 2;
+                float left = rect.xMin + d * x;
+                float right = rect.xMax - d * (bounds.size.x - x);
+                float top = rect.yMax - d * x;
+                float bottom = rect.yMin + d * (bounds.size.x - x);
                 Handles.DrawLine(new Vector3(left, bottom), new Vector3(right, top));
             }
             Handles.color = Color.white;
 
-            // Icons
-            for (int y = 0; y <= 2; y++)
-            {
-                for (int x = 0; x <= 2; x++)
-                {
-                    Rect r = new Rect(
-                        rect.xMin + ((x + y) * rect.width) / 6, 
-                        rect.yMin + ((2 - x + y) * rect.height) / 6, 
-                        w - 1, h - 1);
-                    if (x != 1 || y != 1)
-                    {
-                        RuleOnGUI(r, s_Arrows[y, x], tilingRule.m_Neighbors[index]);
-                        RuleNeighborUpdate(r, tilingRule, index);
+            var neighbors = tilingRule.GetNeighbors();
 
-                        index++;
+            // Icons
+            float iconSize = rect.width / (bounds.size.x + bounds.size.y);
+            var rect2 = new Rect(rect);
+            rect2.xMin += iconSize * 0.5f;
+            rect2.xMax -= iconSize * 0.5f;
+            rect2.yMin += iconSize * 0.5f;
+            rect2.yMax -= iconSize * 0.5f;
+            iconSize = rect2.width / (bounds.size.x + bounds.size.y - 1);
+            float p = Mathf.Pow(2, 0.5f);
+
+            for (int y = bounds.yMin; y < bounds.yMax; y++)
+            {
+                for (int x = bounds.xMin; x < bounds.xMax; x++)
+                {
+                    Vector3Int pos = new Vector3Int(x, y, 0);
+                    Vector3Int offset = new Vector3Int(pos.x - bounds.xMin, pos.y - bounds.yMin, 0);
+                    Rect r = new Rect(
+                        rect2.xMin + iconSize * (offset.x + offset.y) - iconSize * 0.5f + d * 0.5f,
+                        rect2.yMin + iconSize * (offset.y - offset.x) + rect2.height - bounds.size.y * iconSize,
+                        iconSize, iconSize
+                    );
+                    Vector2 center = r.center;
+                    r.size *= p;
+                    r.center = center;
+                    if (x != 0 || y != 0)
+                    {
+                        if (neighbors.ContainsKey(pos))
+                        {
+                            RuleOnGUI(r, pos, neighbors[pos]);
+                            RuleTooltipOnGUI(r, neighbors[pos]);
+                        }
+                        if (RuleNeighborUpdate(r, tilingRule, neighbors, pos))
+                        {
+                            tile.UpdateRemoteRulePositions();
+                        }
                     }
                     else
                     {
                         RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
-                        RuleTransformUpdate(r, tilingRule);
+                        if (RuleTransformUpdate(r, tilingRule))
+                        {
+                            tile.UpdateRemoteRulePositions();
+                        }
                     }
                 }
             }
         }
 
-        internal override bool ContainsMousePosition(Rect rect)
+        public override bool ContainsMousePosition(Rect rect)
         {
             var center = rect.center;
             var halfWidth = rect.width / 2;

--- a/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
+++ b/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
@@ -230,7 +230,7 @@ namespace UnityEditor
                     RuleTileEditor.RuleInspectorOnGUI(inspectorRect, originalRule);
                 else
                     RuleOriginalDefaultInspectorOnGUI(inspectorRect, originalRule);
-                ruleTileEditor.RuleMatrixOnGUI(overrideTile.m_Tile, matrixRect, originalRule);
+                ruleTileEditor.RuleMatrixOnGUI(overrideTile.m_Tile, matrixRect, originalRule.bounds, originalRule);
                 RuleTileEditor.SpriteOnGUI(spriteRect, originalRule);
 
                 DestroyImmediate(ruleTileEditor);

--- a/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
+++ b/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
@@ -230,7 +230,7 @@ namespace UnityEditor
                     RuleTileEditor.RuleInspectorOnGUI(inspectorRect, originalRule);
                 else
                     RuleOriginalDefaultInspectorOnGUI(inspectorRect, originalRule);
-                ruleTileEditor.RuleMatrixOnGUI(overrideTile.m_Tile, matrixRect, originalRule.bounds, originalRule);
+                ruleTileEditor.RuleMatrixOnGUI(overrideTile.m_Tile, matrixRect, ruleTileEditor.GetRuleGUIBounds(originalRule), originalRule);
                 RuleTileEditor.SpriteOnGUI(spriteRect, originalRule);
 
                 DestroyImmediate(ruleTileEditor);

--- a/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
+++ b/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
@@ -11,12 +11,27 @@ namespace UnityEditor
     {
 
         public RuleOverrideTile overrideTile { get { return (target as RuleOverrideTile); } }
+        public RuleTileEditor ruleTileEditor
+        {
+            get
+            {
+                if (m_RuleTileEditorTile != overrideTile.m_Tile)
+                {
+                    DestroyImmediate(m_RuleTileEditor);
+                    m_RuleTileEditor = Editor.CreateEditor(overrideTile.m_Tile) as RuleTileEditor;
+                    m_RuleTileEditorTile = overrideTile.m_Tile;
+                }
+                return m_RuleTileEditor;
+            }
+        }
 
         private List<KeyValuePair<Sprite, Sprite>> m_Sprites;
         private List<KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRule>> m_Rules;
 
         ReorderableList m_SpriteList;
         ReorderableList m_RuleList;
+        RuleTileEditor m_RuleTileEditor;
+        RuleTile m_RuleTileEditorTile;
 
         private float k_DefaultElementHeight { get { return RuleTileEditor.k_DefaultElementHeight; } }
         private float k_PaddingBetweenRules { get { return RuleTileEditor.k_PaddingBetweenRules; } }
@@ -49,6 +64,12 @@ namespace UnityEditor
                 m_RuleList.drawElementCallback = DrawRuleElement;
                 m_RuleList.elementHeightCallback = GetRuleElementHeight;
             }
+        }
+
+        void OnDisable()
+        {
+            DestroyImmediate(ruleTileEditor);
+            m_RuleTileEditorTile = null;
         }
 
         public override void OnInspectorGUI()
@@ -220,20 +241,31 @@ namespace UnityEditor
                 float height = rect.height - k_PaddingBetweenRules;
                 float matrixWidth = k_DefaultElementHeight;
 
+                BoundsInt ruleBounds = originalRule.GetBounds();
+                BoundsInt ruleGuiBounds = ruleTileEditor.GetRuleGUIBounds(ruleBounds, originalRule);
+                Vector2 matrixSize = ruleTileEditor.GetMatrixSize(ruleGuiBounds);
+                Vector2 matrixSizeRate = matrixSize / Mathf.Max(matrixSize.x, matrixSize.y);
+                Vector2 matrixRectSize = new Vector2(matrixWidth * matrixSizeRate.x, k_DefaultElementHeight * matrixSizeRate.y);
+                Vector2 matrixRectPosition = new Vector2(rect.xMax - matrixWidth * 2f - 10f, yPos);
+                matrixRectPosition.x += (matrixWidth - matrixRectSize.x) * 0.5f;
+                matrixRectPosition.y += (k_DefaultElementHeight - matrixRectSize.y) * 0.5f;
+
                 Rect inspectorRect = new Rect(rect.xMin, yPos, rect.width - matrixWidth * 2f - 20f, height);
-                Rect matrixRect = new Rect(rect.xMax - matrixWidth * 2f - 10f, yPos, matrixWidth, k_DefaultElementHeight);
+                Rect matrixRect = new Rect(matrixRectPosition, matrixRectSize);
                 Rect spriteRect = new Rect(rect.xMax - matrixWidth - 5f, yPos, matrixWidth, k_DefaultElementHeight);
 
-                RuleTileEditor ruleTileEditor = Editor.CreateEditor(overrideTile.m_Tile) as RuleTileEditor;
 
                 if (!isDefault)
-                    RuleTileEditor.RuleInspectorOnGUI(inspectorRect, originalRule);
+                {
+                    ruleTileEditor.RuleInspectorOnGUI(inspectorRect, originalRule);
+                    ruleTileEditor.RuleMatrixOnGUI(overrideTile.m_Tile, matrixRect, ruleGuiBounds, originalRule);
+                }
                 else
+                {
                     RuleOriginalDefaultInspectorOnGUI(inspectorRect, originalRule);
-                ruleTileEditor.RuleMatrixOnGUI(overrideTile.m_Tile, matrixRect, ruleTileEditor.GetRuleGUIBounds(originalRule), originalRule);
-                RuleTileEditor.SpriteOnGUI(spriteRect, originalRule);
+                }
 
-                DestroyImmediate(ruleTileEditor);
+                ruleTileEditor.SpriteOnGUI(spriteRect, originalRule);
             }
         }
         private void DrawOverrideElement(Rect rect, RuleTile.TilingRule originalRule)
@@ -248,7 +280,7 @@ namespace UnityEditor
             RuleOverrideInspectorOnGUI(inspectorRect, originalRule);
             RuleTile.TilingRule overrideRule = overrideTile[originalRule];
             if (overrideRule != null)
-                RuleTileEditor.SpriteOnGUI(spriteRect, overrideRule);
+                ruleTileEditor.SpriteOnGUI(spriteRect, overrideRule);
         }
         private void RuleOriginalDefaultInspectorOnGUI(Rect rect, RuleTile.TilingRule originalRule)
         {
@@ -339,7 +371,7 @@ namespace UnityEditor
 
             RuleOverrideDefaultInspectorOnGUI(inspectorRect, originalRule);
             if (overrideTile.m_OverrideDefault.m_Enabled)
-                RuleTileEditor.SpriteOnGUI(spriteRect, overrideTile.m_OverrideDefault.m_TilingRule);
+                ruleTileEditor.SpriteOnGUI(spriteRect, overrideTile.m_OverrideDefault.m_TilingRule);
         }
         private void RuleOverrideDefaultInspectorOnGUI(Rect rect, RuleTile.TilingRule overrideRule)
         {

--- a/Editor/Tiles/RuleTile/RuleTileEditor.cs
+++ b/Editor/Tiles/RuleTile/RuleTileEditor.cs
@@ -83,9 +83,8 @@ namespace UnityEditor
             m_ReorderableList.onAddCallback = OnAddElement;
         }
 
-        public virtual BoundsInt GetRuleGUIBounds(RuleTile.TilingRule rule)
+        public virtual BoundsInt GetRuleGUIBounds(BoundsInt bounds, RuleTile.TilingRule rule)
         {
-            BoundsInt bounds = rule.bounds;
             if (extendNeighbor)
             {
                 bounds.xMin--;
@@ -108,7 +107,7 @@ namespace UnityEditor
         private float GetElementHeight(int index)
         {
             RuleTile.TilingRule rule = tile.m_TilingRules[index];
-            BoundsInt bounds = GetRuleGUIBounds(rule);
+            BoundsInt bounds = GetRuleGUIBounds(rule.GetBounds(), rule);
 
             float inspectorHeight = k_DefaultElementHeight + k_PaddingBetweenRules;
             float matrixHeight = GetMatrixSize(bounds).y + 10f;
@@ -129,7 +128,7 @@ namespace UnityEditor
             return Mathf.Max(inspectorHeight, matrixHeight);
         }
 
-        protected virtual Vector2 GetMatrixSize(BoundsInt bounds)
+        public virtual Vector2 GetMatrixSize(BoundsInt bounds)
         {
             return new Vector2(bounds.size.x * k_SingleLineHeight, bounds.size.y * k_SingleLineHeight);
         }
@@ -137,7 +136,7 @@ namespace UnityEditor
         protected virtual void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
         {
             RuleTile.TilingRule rule = tile.m_TilingRules[index];
-            BoundsInt bounds = GetRuleGUIBounds(rule);
+            BoundsInt bounds = GetRuleGUIBounds(rule.GetBounds(), rule);
 
             float yPos = rect.yMin + 2f;
             float height = rect.height - k_PaddingBetweenRules;
@@ -430,12 +429,12 @@ namespace UnityEditor
             }
         }
 
-        public static void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+        public virtual void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
         {
             tilingRule.m_Sprites[0] = EditorGUI.ObjectField(new Rect(rect.xMax - rect.height, rect.yMin, rect.height, rect.height), tilingRule.m_Sprites[0], typeof(Sprite), false) as Sprite;
         }
 
-        public static void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+        public virtual void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
         {
             float y = rect.yMin;
             EditorGUI.BeginChangeCheck();

--- a/Editor/Tiles/RuleTile/RuleTileEditor.cs
+++ b/Editor/Tiles/RuleTile/RuleTileEditor.cs
@@ -64,13 +64,14 @@ namespace UnityEditor
             }
         }
 
-        private RuleTile tile { get { return (target as RuleTile); } }
+        public RuleTile tile { get { return (target as RuleTile); } }
         private ReorderableList m_ReorderableList;
+        public bool extendNeighbor;
 
-        internal const float k_DefaultElementHeight = 48f;
-        internal const float k_PaddingBetweenRules = 26f;
-        internal const float k_SingleLineHeight = 16f;
-        internal const float k_LabelWidth = 80f;
+        public const float k_DefaultElementHeight = 48f;
+        public const float k_PaddingBetweenRules = 26f;
+        public const float k_SingleLineHeight = 16f;
+        public const float k_LabelWidth = 80f;
 
         public void OnEnable()
         {
@@ -82,6 +83,23 @@ namespace UnityEditor
             m_ReorderableList.onAddCallback = OnAddElement;
         }
 
+        public virtual BoundsInt GetRuleGUIBounds(RuleTile.TilingRule rule)
+        {
+            BoundsInt bounds = rule.bounds;
+            if (extendNeighbor)
+            {
+                bounds.xMin--;
+                bounds.yMin--;
+                bounds.xMax++;
+                bounds.yMax++;
+            }
+            bounds.xMin = Mathf.Min(bounds.xMin, -1);
+            bounds.yMin = Mathf.Min(bounds.yMin, -1);
+            bounds.xMax = Mathf.Max(bounds.xMax, 2);
+            bounds.yMax = Mathf.Max(bounds.yMax, 2);
+            return bounds;
+        }
+
         private void ListUpdated(ReorderableList list)
         {
             SaveTile();
@@ -89,34 +107,49 @@ namespace UnityEditor
 
         private float GetElementHeight(int index)
         {
-            if (tile.m_TilingRules != null && tile.m_TilingRules.Count > 0)
+            RuleTile.TilingRule rule = tile.m_TilingRules[index];
+            BoundsInt bounds = GetRuleGUIBounds(rule);
+
+            float inspectorHeight = k_DefaultElementHeight + k_PaddingBetweenRules;
+            float matrixHeight = GetMatrixSize(bounds).y + 10f;
+
+            if (index < tile.m_TilingRules.Count)
             {
                 switch (tile.m_TilingRules[index].m_Output)
                 {
                     case RuleTile.TilingRule.OutputSprite.Random:
-                        return k_DefaultElementHeight + k_SingleLineHeight * (tile.m_TilingRules[index].m_Sprites.Length + 3) + k_PaddingBetweenRules;
+                        inspectorHeight = k_DefaultElementHeight + k_SingleLineHeight * (tile.m_TilingRules[index].m_Sprites.Length + 3) + k_PaddingBetweenRules;
+                        break;
                     case RuleTile.TilingRule.OutputSprite.Animation:
-                        return k_DefaultElementHeight + k_SingleLineHeight * (tile.m_TilingRules[index].m_Sprites.Length + 2) + k_PaddingBetweenRules;
+                        inspectorHeight = k_DefaultElementHeight + k_SingleLineHeight * (tile.m_TilingRules[index].m_Sprites.Length + 2) + k_PaddingBetweenRules;
+                        break;
                 }
             }
-            return k_DefaultElementHeight + k_PaddingBetweenRules;
+
+            return Mathf.Max(inspectorHeight, matrixHeight);
         }
 
-        private void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
+        protected virtual Vector2 GetMatrixSize(BoundsInt bounds)
+        {
+            return new Vector2(bounds.size.x * k_SingleLineHeight, bounds.size.y * k_SingleLineHeight);
+        }
+
+        protected virtual void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
         {
             RuleTile.TilingRule rule = tile.m_TilingRules[index];
+            BoundsInt bounds = GetRuleGUIBounds(rule);
 
             float yPos = rect.yMin + 2f;
             float height = rect.height - k_PaddingBetweenRules;
-            float matrixWidth = k_DefaultElementHeight;
+            Vector2 matrixSize = GetMatrixSize(bounds);
 
-            Rect inspectorRect = new Rect(rect.xMin, yPos, rect.width - matrixWidth * 2f - 20f, height);
-            Rect matrixRect = new Rect(rect.xMax - matrixWidth * 2f - 10f, yPos, matrixWidth, k_DefaultElementHeight);
-            Rect spriteRect = new Rect(rect.xMax - matrixWidth - 5f, yPos, matrixWidth, k_DefaultElementHeight);
+            Rect spriteRect = new Rect(rect.xMax - k_DefaultElementHeight - 5f, yPos, k_DefaultElementHeight, k_DefaultElementHeight);
+            Rect matrixRect = new Rect(rect.xMax - matrixSize.x - spriteRect.width - 10f, yPos, matrixSize.x, matrixSize.y);
+            Rect inspectorRect = new Rect(rect.xMin, yPos, rect.width - matrixSize.x - spriteRect.width - 20f, height);
 
             EditorGUI.BeginChangeCheck();
             RuleInspectorOnGUI(inspectorRect, rule);
-            RuleMatrixOnGUI(tile, matrixRect, rule);
+            RuleMatrixOnGUI(tile, matrixRect, bounds, rule);
             SpriteOnGUI(spriteRect, rule);
             if (EditorGUI.EndChangeCheck())
                 SaveTile();
@@ -132,7 +165,7 @@ namespace UnityEditor
             tile.m_TilingRules.Add(rule);
         }
 
-        private void SaveTile()
+        public void SaveTile()
         {
             EditorUtility.SetDirty(target);
             SceneView.RepaintAll();
@@ -155,6 +188,17 @@ namespace UnityEditor
         private void OnDrawHeader(Rect rect)
         {
             GUI.Label(rect, "Tiling Rules");
+
+            Rect toggleRect = new Rect(rect.xMax - rect.height, rect.y, rect.height, rect.height);
+            Rect toggleLabelRect = new Rect(rect.x, rect.y, rect.width - toggleRect.width - 5f, rect.height);
+
+            extendNeighbor = EditorGUI.Toggle(toggleRect, extendNeighbor);
+            EditorGUI.LabelField(toggleLabelRect, "Extend Neighbor", new GUIStyle()
+            {
+                alignment = TextAnchor.MiddleRight,
+                fontStyle = FontStyle.Bold,
+                fontSize = 10,
+            });
         }
 
         public override void OnInspectorGUI()
@@ -174,7 +218,7 @@ namespace UnityEditor
 
             EditorGUILayout.Space();
 
-            if (m_ReorderableList != null && tile.m_TilingRules != null)
+            if (m_ReorderableList != null)
                 m_ReorderableList.DoLayoutList();
         }
 
@@ -182,19 +226,48 @@ namespace UnityEditor
         {
             var customFields = tile.GetType().GetFields()
                 .Where(field => typeof(RuleTile).GetField(field.Name) == null)
+                .Where(field => !field.IsStatic)
                 .Where(field => field.FieldType.IsSerializable);
             foreach (var field in customFields)
                 EditorGUILayout.PropertyField(serializedObject.FindProperty(field.Name), true);
         }
+    
+        public virtual int GetArrowIndex(Vector3Int position)
+        {
+            if (Mathf.Abs(position.x) == Mathf.Abs(position.y))
+            {
+                if (position.x < 0 && position.y > 0)
+                    return 0;
+                else if (position.x > 0 && position.y > 0)
+                    return 2;
+                else if (position.x < 0 && position.y < 0)
+                    return 6;
+                else if (position.x > 0 && position.y < 0)
+                    return 8;
+            }
+            else if (Mathf.Abs(position.x) > Mathf.Abs(position.y))
+            {
+                if (position.x > 0)
+                    return 5;
+                else
+                    return 3;
+            }
+            else
+            {
+                if (position.y > 0)
+                    return 1;
+                else
+                    return 7;
+            }
+            return -1;
+        }
 
-        internal virtual void RuleOnGUI(Rect rect, int arrowIndex, int neighbor)
+        public virtual void RuleOnGUI(Rect rect, Vector3Int position, int neighbor)
         {
             switch (neighbor)
             {
-                case RuleTile.TilingRule.Neighbor.DontCare:
-                    break;
                 case RuleTile.TilingRule.Neighbor.This:
-                    GUI.DrawTexture(rect, arrows[arrowIndex]);
+                    GUI.DrawTexture(rect, arrows[GetArrowIndex(position)]);
                     break;
                 case RuleTile.TilingRule.Neighbor.NotThis:
                     GUI.DrawTexture(rect, arrows[9]);
@@ -206,6 +279,10 @@ namespace UnityEditor
                     GUI.Label(rect, neighbor.ToString(), style);
                     break;
             }
+        }
+
+        public void RuleTooltipOnGUI(Rect rect, int neighbor)
+        {
             var allConsts = tile.m_NeighborType.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
             foreach (var c in allConsts)
             {
@@ -217,7 +294,7 @@ namespace UnityEditor
             }
         }
 
-        internal virtual void RuleTransformOnGUI(Rect rect, RuleTile.TilingRule.Transform ruleTransform)
+        public virtual void RuleTransformOnGUI(Rect rect, RuleTile.TilingRule.Transform ruleTransform)
         {
             switch (ruleTransform)
             {
@@ -233,33 +310,67 @@ namespace UnityEditor
             }
         }
 
-        internal void RuleNeighborUpdate(Rect rect, RuleTile.TilingRule tilingRule, int index)
+        public bool RuleNeighborUpdate(Rect rect, RuleTile.TilingRule tilingRule, Dictionary<Vector3Int, int> neighbors
+, Vector3Int position)
         {
             if (Event.current.type == EventType.MouseDown && ContainsMousePosition(rect))
             {
                 var allConsts = tile.m_NeighborType.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-                var neighbors = allConsts.Select(c => (int)c.GetValue(null)).ToList();
-                neighbors.Sort();
+                var neighborConsts = allConsts.Select(c => (int)c.GetValue(null)).ToList();
+                neighborConsts.Sort();
 
-                int oldIndex = neighbors.IndexOf(tilingRule.m_Neighbors[index]);
-                int newIndex = (int)Mathf.Repeat(oldIndex + GetMouseChange(), neighbors.Count);
-                tilingRule.m_Neighbors[index] = neighbors[newIndex];
+                if (neighbors.ContainsKey(position))
+                {
+                    int oldIndex = neighborConsts.IndexOf(neighbors[position]);
+                    int newIndex = oldIndex + GetMouseChange();
+                    if (newIndex >= 0 && newIndex < neighborConsts.Count)
+                    {
+                        newIndex = (int)Mathf.Repeat(newIndex, neighborConsts.Count);
+                        neighbors[position] = neighborConsts[newIndex];
+                    }
+                    else
+                    {
+                        neighbors.Remove(position);
+                    }
+                }
+                else
+                {
+                    int mouseChange = GetMouseChange();
+                    if (mouseChange == 1)
+                    {
+                        neighbors.Add(position, neighborConsts[0]);
+                    }
+                    else
+                    {
+                        neighbors.Add(position, neighborConsts[neighborConsts.Count - 1]);
+                    }
+                }
+                tilingRule.ApplyNeighbors(neighbors);
+
                 GUI.changed = true;
                 Event.current.Use();
+
+                return true;
             }
+
+            return false;
         }
 
-        internal void RuleTransformUpdate(Rect rect, RuleTile.TilingRule tilingRule)
+        public bool RuleTransformUpdate(Rect rect, RuleTile.TilingRule tilingRule)
         {
             if (Event.current.type == EventType.MouseDown && ContainsMousePosition(rect))
             {
                 tilingRule.m_RuleTransform = (RuleTile.TilingRule.Transform)(int)Mathf.Repeat((int)tilingRule.m_RuleTransform + GetMouseChange(), 4);
                 GUI.changed = true;
                 Event.current.Use();
+
+                return true;
             }
+
+            return false;
         }
 
-        internal virtual bool ContainsMousePosition(Rect rect)
+        public virtual bool ContainsMousePosition(Rect rect)
         {
             return rect.Contains(Event.current.mousePosition);
         }
@@ -269,52 +380,62 @@ namespace UnityEditor
             return Event.current.button == 1 ? -1 : 1;
         }
 
-        internal virtual void RuleMatrixOnGUI(RuleTile tile, Rect rect, RuleTile.TilingRule tilingRule)
+        public virtual void RuleMatrixOnGUI(RuleTile tile, Rect rect, BoundsInt bounds, RuleTile.TilingRule tilingRule)
         {
             Handles.color = EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.2f) : new Color(0f, 0f, 0f, 0.2f);
-            int index = 0;
-            float w = rect.width / 3f;
-            float h = rect.height / 3f;
+            float w = rect.width / bounds.size.x;
+            float h = rect.height / bounds.size.y;
 
-            for (int y = 0; y <= 3; y++)
+            for (int y = 0; y <= bounds.size.y; y++)
             {
                 float top = rect.yMin + y * h;
                 Handles.DrawLine(new Vector3(rect.xMin, top), new Vector3(rect.xMax, top));
             }
-            for (int x = 0; x <= 3; x++)
+            for (int x = 0; x <= bounds.size.x; x++)
             {
                 float left = rect.xMin + x * w;
                 Handles.DrawLine(new Vector3(left, rect.yMin), new Vector3(left, rect.yMax));
             }
             Handles.color = Color.white;
 
-            for (int y = 0; y <= 2; y++)
-            {
-                for (int x = 0; x <= 2; x++)
-                {
-                    Rect r = new Rect(rect.xMin + x * w, rect.yMin + y * h, w - 1, h - 1);
-                    if (x != 1 || y != 1)
-                    {
-                        RuleOnGUI(r, y * 3 + x, tilingRule.m_Neighbors[index]);
-                        RuleNeighborUpdate(r, tilingRule, index);
+            var neighbors = tilingRule.GetNeighbors();
 
-                        index++;
+            for (int y = bounds.yMin; y < bounds.yMax; y++)
+            {
+                for (int x = bounds.xMin; x < bounds.xMax; x++)
+                {
+                    Vector3Int pos = new Vector3Int(x, y, 0);
+                    Rect r = new Rect(rect.xMin + (x - bounds.xMin) * w, rect.yMin + (-y + bounds.yMax - 1) * h, w - 1, h - 1);
+                    if (x != 0 || y != 0)
+                    {
+                        if (neighbors.ContainsKey(pos))
+                        {
+                            RuleOnGUI(r, pos, neighbors[pos]);
+                            RuleTooltipOnGUI(r, neighbors[pos]);
+                        }
+                        if (RuleNeighborUpdate(r, tilingRule, neighbors, pos))
+                        {
+                            tile.UpdateRemoteRulePositions();
+                        }
                     }
                     else
                     {
                         RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
-                        RuleTransformUpdate(r, tilingRule);
+                        if (RuleTransformUpdate(r, tilingRule))
+                        {
+                            tile.UpdateRemoteRulePositions();
+                        }
                     }
                 }
             }
         }
 
-        internal static void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+        public static void SpriteOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
         {
             tilingRule.m_Sprites[0] = EditorGUI.ObjectField(new Rect(rect.xMax - rect.height, rect.yMin, rect.height, rect.height), tilingRule.m_Sprites[0], typeof(Sprite), false) as Sprite;
         }
 
-        internal static void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
+        public static void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRule tilingRule)
         {
             float y = rect.yMin;
             EditorGUI.BeginChangeCheck();

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine.Tilemaps;
 
 namespace UnityEngine
 {
@@ -25,100 +24,105 @@ namespace UnityEngine
     [CreateAssetMenu(fileName = "New Hexagonal Rule Tile", menuName = "Tiles/Hexagonal Rule Tile")]
     public class HexagonalRuleTile : RuleTile
     {
-        private static readonly int[,] RotatedOrMirroredIndexes =
-        {
-            {3, 2, 1, 0, 5, 4}, // X, Pointed
-            {0, 5, 4, 3, 2, 1}, // Y, Pointed
-            {3, 4, 5, 0, 1, 2}, // XY
-            {0, 5, 4, 3, 2, 1}, // X, FlatTop
-            {3, 2, 1, 0, 5, 4}, // Y, FlatTop
-        };
-
-        private static readonly Vector3Int[,] PointedTopNeighborOffsets =
-        {
-            {
-                new Vector3Int(1, 0, 0), new Vector3Int(0, -1, 0), new Vector3Int(-1, -1, 0), new Vector3Int(-1, 0, 0), new Vector3Int(-1, 1, 0), new Vector3Int(0, 1, 0)
-            },
-            {
-                new Vector3Int(1, 0, 0), new Vector3Int(1, -1, 0), new Vector3Int(0, -1, 0), new Vector3Int(-1, 0, 0), new Vector3Int(0, 1, 0), new Vector3Int(1, 1, 0)
-            }
-        };
-        private static readonly Vector3Int[,] FlatTopNeighborOffsets =
-        {
-            {
-                new Vector3Int(1, 0, 0), new Vector3Int(0, 1, 0), new Vector3Int(-1, 1, 0), new Vector3Int(-1, 0, 0), new Vector3Int(-1, -1, 0), new Vector3Int(0, -1, 0)
-            },
-            {
-                new Vector3Int(1, 0, 0), new Vector3Int(1, 1, 0), new Vector3Int(0, 1, 0), new Vector3Int(-1, 0, 0), new Vector3Int(0, -1, 0), new Vector3Int(1, -1, 0)
-            }
-        };
-
-        private static readonly int NeighborCount = 6;
 
         /// <summary>
         /// Returns the number of neighbors a Rule Tile can have.
         /// </summary>
-        public override int neighborCount
+        public int neighborCount => 6;
+
+        public override int m_RotationAngle => 60;
+        public override Vector3Int[] m_NearbyNeighborPositions => new Vector3Int[] {
+            new Vector3Int(-1, 1, 0),
+            new Vector3Int(0, 1, 0),
+            new Vector3Int(-1, 0, 0),
+            new Vector3Int(1, 0, 0),
+            new Vector3Int(-1, -1, 0),
+            new Vector3Int(0, -1, 0),
+        };
+        public override bool IsNearbyNeighborPosition(Vector3Int position)
         {
-            get { return NeighborCount; }
+            return (position.x >= -1 && position.x <= 0 && position.y >= -1 && position.y <= 1) || position == Vector3Int.right;
         }
+
+        private static float[] m_CosAngleArr1 = {
+            Mathf.Cos(0 * Mathf.Deg2Rad),
+            Mathf.Cos(-60 * Mathf.Deg2Rad),
+            Mathf.Cos(-120 * Mathf.Deg2Rad),
+            Mathf.Cos(-180 * Mathf.Deg2Rad),
+            Mathf.Cos(-240 * Mathf.Deg2Rad),
+            Mathf.Cos(-300 * Mathf.Deg2Rad),
+        };
+        private static float[] m_SinAngleArr1 = {
+            Mathf.Sin(0 * Mathf.Deg2Rad),
+            Mathf.Sin(-60 * Mathf.Deg2Rad),
+            Mathf.Sin(-120 * Mathf.Deg2Rad),
+            Mathf.Sin(-180 * Mathf.Deg2Rad),
+            Mathf.Sin(-240 * Mathf.Deg2Rad),
+            Mathf.Sin(-300 * Mathf.Deg2Rad),
+        };
+        private static float[] m_CosAngleArr2 = {
+            Mathf.Cos(0 * Mathf.Deg2Rad),
+            Mathf.Cos(60 * Mathf.Deg2Rad),
+            Mathf.Cos(120 * Mathf.Deg2Rad),
+            Mathf.Cos(180 * Mathf.Deg2Rad),
+            Mathf.Cos(240 * Mathf.Deg2Rad),
+            Mathf.Cos(300 * Mathf.Deg2Rad),
+        };
+        private static float[] m_SinAngleArr2 = {
+            Mathf.Sin(0 * Mathf.Deg2Rad),
+            Mathf.Sin(60 * Mathf.Deg2Rad),
+            Mathf.Sin(120 * Mathf.Deg2Rad),
+            Mathf.Sin(180 * Mathf.Deg2Rad),
+            Mathf.Sin(240 * Mathf.Deg2Rad),
+            Mathf.Sin(300 * Mathf.Deg2Rad),
+        };
 
         /// <summary>
         /// Whether this is a flat top Hexagonal Tile
         /// </summary>
         public bool m_FlatTop;
 
-        /// <summary>
-        /// This method is called when the tile is refreshed.
-        /// </summary>
-        /// <param name="location">Position of the Tile on the Tilemap.</param>
-        /// <param name="tileMap">The Tilemap the tile is present on.</param>
-        public override void RefreshTile(Vector3Int location, ITilemap tileMap)
+        static float m_TilemapToWorldYScale = Mathf.Pow(1 - Mathf.Pow(0.5f, 2f), 0.5f);
+
+        public static Vector3 TilemapPositionToWorldPosition(Vector3Int tilemapPosition)
         {
-            if (m_TilingRules != null && m_TilingRules.Count > 0)
-            {
-                for (int i = 0; i < neighborCount; ++i)
-                {
-                    base.RefreshTile(location + GetOffsetPosition(location, i), tileMap);
-                }
-            }
-            base.RefreshTile(location, tileMap);
+            Vector3 worldPosition = new Vector3(tilemapPosition.x, tilemapPosition.y);
+            if (tilemapPosition.y % 2 != 0)
+                worldPosition.x += 0.5f;
+            worldPosition.y *= m_TilemapToWorldYScale;
+            return worldPosition;
         }
 
-        /// <summary>
-        /// Does a Rule Match given a Tiling Rule and neighboring Tiles.
-        /// </summary>
-        /// <param name="rule">The Tiling Rule to match with.</param>
-        /// <param name="neighboringTiles">The neighboring Tiles to match with.</param>
-        /// <param name="transform">A transform matrix which will match the Rule.</param>
-        /// <returns>True if there is a match, False if not.</returns>
-        protected override bool RuleMatches(TilingRule rule, ref TileBase[] neighboringTiles, ref Matrix4x4 transform)
+        public static Vector3Int WorldPositionToTilemapPosition(Vector3 worldPosition)
         {
-            // Check rule against rotations of 0, 60, 120, 180, 240, 300
-            for (int angle = 0; angle <= (rule.m_RuleTransform == TilingRule.Transform.Rotated ? 300 : 0); angle += 60)
-            {
-                if (RuleMatches(rule, ref neighboringTiles, angle))
-                {
-                    transform = Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(0f, 0f, -angle), Vector3.one);
-                    return true;
-                }
-            }
+            worldPosition.y /= m_TilemapToWorldYScale;
+            Vector3Int tilemapPosition = new Vector3Int();
+            tilemapPosition.y = Mathf.RoundToInt(worldPosition.y);
+            if (tilemapPosition.y % 2 != 0)
+                tilemapPosition.x = Mathf.RoundToInt(worldPosition.x - 0.5f);
+            else
+                tilemapPosition.x = Mathf.RoundToInt(worldPosition.x);
+            return tilemapPosition;
+        }
 
-            // Check rule against x-axis mirror
-            if ((rule.m_RuleTransform == TilingRule.Transform.MirrorX) && RuleMatches(rule, ref neighboringTiles, true, false))
-            {
-                transform = Matrix4x4.TRS(Vector3.zero, Quaternion.identity, new Vector3(-1f, 1f, 1f));
-                return true;
-            }
+        protected override Vector3Int GetOffsetPosition(Vector3Int location, Vector3Int offset)
+        {
+            Vector3Int position = location + offset;
 
-            // Check rule against y-axis mirror
-            if ((rule.m_RuleTransform == TilingRule.Transform.MirrorY) && RuleMatches(rule, ref neighboringTiles, false, true))
-            {
-                transform = Matrix4x4.TRS(Vector3.zero, Quaternion.identity, new Vector3(1f, -1f, 1f));
-                return true;
-            }
+            if (offset.y % 2 != 0 && location.y % 2 != 0)
+                position.x += 1;
 
-            return false;
+            return position;
+        }
+
+        protected override Vector3Int GetOffsetPositionReverse(Vector3Int position, Vector3Int offset)
+        {
+            Vector3Int location = position - offset;
+
+            if (offset.y % 2 != 0 && location.y % 2 != 0)
+                location.x -= 1;
+
+            return location;
         }
 
         /// <summary>
@@ -146,66 +150,69 @@ namespace UnityEngine
         }
 
         /// <summary>
-        /// Gets and caches the neighboring Tiles around the given Tile on the Tilemap.
+        /// Gets a rotated position given its original position and the rotation in degrees. 
         /// </summary>
-        /// <param name="tilemap">The Tilemap the tile is present on.</param>
-        /// <param name="position">Position of the Tile on the Tilemap.</param>
-        /// <param name="neighboringTiles">An array storing the neighboring Tiles</param>
-        protected override void GetMatchingNeighboringTiles(ITilemap tilemap, Vector3Int position, ref TileBase[] neighboringTiles)
-        {
-            if (neighboringTiles != null)
-                return;
-
-            if (m_CachedNeighboringTiles == null || m_CachedNeighboringTiles.Length < neighborCount)
-                m_CachedNeighboringTiles = new TileBase[neighborCount];
-
-            for (int index = 0; index < neighborCount; ++index)
-            {
-                Vector3Int tilePosition = position + GetOffsetPosition(position, index);
-                m_CachedNeighboringTiles[index] = tilemap.GetTile(tilePosition);
-            }
-            neighboringTiles = m_CachedNeighboringTiles;
-        }
-
-        /// <summary>
-        /// Gets a rotated index given its original index and the rotation in degrees. 
-        /// </summary>
-        /// <param name="original">Original index of Tile.</param>
+        /// <param name="position">Original position of Tile.</param>
         /// <param name="rotation">Rotation in degrees.</param>
-        /// <returns>Rotated Index of Tile.</returns>
-        protected override int GetRotatedIndex(int original, int rotation)
+        /// <returns>Rotated position of Tile.</returns>
+        protected override Vector3Int GetRotatedPosition(Vector3Int position, int rotation)
         {
-            return (original + rotation / 60) % neighborCount;
+            if (rotation != 0)
+            {
+                Vector3 worldPosition = TilemapPositionToWorldPosition(position);
+
+                int index = rotation / 60;
+                if (m_FlatTop)
+                {
+                    worldPosition = new Vector3(
+                        worldPosition.x * m_CosAngleArr2[index] - worldPosition.y * m_SinAngleArr2[index],
+                        worldPosition.x * m_SinAngleArr2[index] + worldPosition.y * m_CosAngleArr2[index]
+                    );
+                }
+                else
+                {
+                    worldPosition = new Vector3(
+                        worldPosition.x * m_CosAngleArr1[index] - worldPosition.y * m_SinAngleArr1[index],
+                        worldPosition.x * m_SinAngleArr1[index] + worldPosition.y * m_CosAngleArr1[index]
+                    );
+                }
+
+                position = WorldPositionToTilemapPosition(worldPosition);
+            }
+            return position;
         }
 
         /// <summary>
-        /// Gets a mirrored index given its original index and the mirroring axii.
+        /// Gets a mirrored position given its original position and the mirroring axii.
         /// </summary>
-        /// <param name="original">Original index of Tile.</param>
+        /// <param name="position">Original position of Tile.</param>
         /// <param name="mirrorX">Mirror in the X Axis.</param>
         /// <param name="mirrorY">Mirror in the Y Axis.</param>
-        /// <returns>Mirrored Index of Tile.</returns>
-        protected override int GetMirroredIndex(int original, bool mirrorX, bool mirrorY)
+        /// <returns>Mirrored position of Tile.</returns>
+        protected override Vector3Int GetMirroredPosition(Vector3Int position, bool mirrorX, bool mirrorY)
         {
-            if (mirrorX && mirrorY)
+            if (mirrorX || mirrorY)
             {
-                return RotatedOrMirroredIndexes[2, original];
-            }
-            if (mirrorX)
-            {
-                return RotatedOrMirroredIndexes[m_FlatTop ? 3 : 0, original];
-            }
-            if (mirrorY)
-            {
-                return RotatedOrMirroredIndexes[m_FlatTop ? 4 : 1, original];
-            }
-            return original;
-        }
+                Vector3 worldPosition = TilemapPositionToWorldPosition(position);
 
-        private Vector3Int GetOffsetPosition(Vector3Int location, int direction)
-        {
-            var parity = location.y & 1;
-            return m_FlatTop ? FlatTopNeighborOffsets[parity, direction] : PointedTopNeighborOffsets[parity, direction];
+                if (m_FlatTop)
+                {
+                    if (mirrorX)
+                        worldPosition.y *= -1;
+                    if (mirrorY)
+                        worldPosition.x *= -1;
+                }
+                else
+                {
+                    if (mirrorX)
+                        worldPosition.x *= -1;
+                    if (mirrorY)
+                        worldPosition.y *= -1;
+                }
+
+                position = WorldPositionToTilemapPosition(worldPosition);
+            }
+            return position;
         }
     }
 }

--- a/Runtime/Tiles/RuleOverrideTile/RuleOverrideTile.cs
+++ b/Runtime/Tiles/RuleOverrideTile/RuleOverrideTile.cs
@@ -297,7 +297,7 @@ namespace UnityEngine.Tilemaps
 
         public void Override()
         {
-            if (!m_Tile)
+            if (!m_Tile || !m_InstanceTile)
                 return;
 
             var tile = m_InstanceTile;
@@ -306,10 +306,9 @@ namespace UnityEngine.Tilemaps
             tile.m_DefaultGameObject = m_Tile.m_DefaultGameObject;
             tile.m_DefaultColliderType = m_Tile.m_DefaultColliderType;
 
-            tile.m_TilingRules = new List<RuleTile.TilingRule>();
-            if (tile.m_TilingRules != null)
-                foreach (var rule in m_Tile.m_TilingRules)
-                    tile.m_TilingRules.Add(CopyTilingRule(rule, new RuleTile.TilingRule(), true));
+            tile.m_TilingRules.Clear();
+            foreach (var rule in m_Tile.m_TilingRules)
+                tile.m_TilingRules.Add(CopyTilingRule(rule, new RuleTile.TilingRule(), true));
 
             if (!m_Advanced)
             {
@@ -328,16 +327,13 @@ namespace UnityEngine.Tilemaps
                     tile.m_DefaultGameObject = m_OverrideDefault.m_TilingRule.m_GameObject;
                     tile.m_DefaultColliderType = m_OverrideDefault.m_TilingRule.m_ColliderType;
                 }
-                if (tile.m_TilingRules != null)
+                for (int i = 0; i < tile.m_TilingRules.Count; i++)
                 {
-                    for (int i = 0; i < tile.m_TilingRules.Count; i++)
-                    {
-                        RuleTile.TilingRule originalRule = tile.m_TilingRules[i];
-                        RuleTile.TilingRule overrideRule = this[m_Tile.m_TilingRules[i]];
-                        if (overrideRule == null)
-                            continue;
-                        CopyTilingRule(overrideRule, originalRule, false);
-                    }
+                    RuleTile.TilingRule originalRule = tile.m_TilingRules[i];
+                    RuleTile.TilingRule overrideRule = this[m_Tile.m_TilingRules[i]];
+                    if (overrideRule == null)
+                        continue;
+                    CopyTilingRule(overrideRule, originalRule, false);
                 }
             }
         }
@@ -356,6 +352,7 @@ namespace UnityEngine.Tilemaps
             if (copyRule)
             {
                 to.m_Neighbors = from.m_Neighbors;
+                to.m_NeighborPositions = from.m_NeighborPositions;
                 to.m_RuleTransform = from.m_RuleTransform;
             }
             to.m_Sprites = from.m_Sprites.Clone() as Sprite[];

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -119,22 +119,6 @@ namespace UnityEngine
             /// </summary>
             public Transform m_RandomTransform;
 
-            public BoundsInt bounds
-            {
-                get
-                {
-                    BoundsInt bounds = new BoundsInt(Vector3Int.zero, Vector3Int.one);
-                    foreach (var neighbor in GetNeighbors())
-                    {
-                        bounds.xMin = Mathf.Min(bounds.xMin, neighbor.Key.x);
-                        bounds.yMin = Mathf.Min(bounds.yMin, neighbor.Key.y);
-                        bounds.xMax = Mathf.Max(bounds.xMax, neighbor.Key.x + 1);
-                        bounds.yMax = Mathf.Max(bounds.yMax, neighbor.Key.y + 1);
-                    }
-                    return bounds;
-                }
-            }
-
             /// <summary>
             /// Constructor for Tiling Rule. This defaults to a Single Output.
             /// </summary>
@@ -161,6 +145,19 @@ namespace UnityEngine
             {
                 m_NeighborPositions = dict.Keys.ToList();
                 m_Neighbors = dict.Values.ToList();
+            }
+
+            public BoundsInt GetBounds()
+            {
+                BoundsInt bounds = new BoundsInt(Vector3Int.zero, Vector3Int.one);
+                foreach (var neighbor in GetNeighbors())
+                {
+                    bounds.xMin = Mathf.Min(bounds.xMin, neighbor.Key.x);
+                    bounds.yMin = Mathf.Min(bounds.yMin, neighbor.Key.y);
+                    bounds.xMax = Mathf.Max(bounds.xMax, neighbor.Key.x + 1);
+                    bounds.yMax = Mathf.Max(bounds.yMax, neighbor.Key.y + 1);
+                }
+                return bounds;
             }
 
             /// <summary>


### PR DESCRIPTION
### Upgrade
- Backward compatible with RuleTile and IsometricRuleTile.
- Not backward compatible with HexagonalRuleTile. The rules need to be reset after the update.

### Change
- [RuleTile] changed from using index to using position.
- [RuleTile] Additional storage rule position.
- [RuleTile] Delete ```DontCare``` rule.
- [RuleTile] Rule list increased ```Extend Neighbor``` toggle. When selected, it will increase the rule range that can be set.
- [RuleTile] No longer fixed to checking around 8 rules.
- [RuleTile] ```RefreshTile()``` will refresh affected remote Tiles.
- [RuleTile] Delete ```GetMatchingNeighboringTiles()```, no longer get nearby Tiles in advance, the performance is affected. (may be changed to cache later)
- [IsometricRuleTile] Rewrite.
- [HexagonalRuleTile] Rewrite.

### Problem
Transfrom rule icon is no longer absolutely in the middle. When the transform rule is Fixed, user may get lost. (I recommend draw a icon for Fixed.)

![image](https://user-images.githubusercontent.com/16279759/67310360-30f35700-f530-11e9-9955-4b43579f9b6b.png)
