### PR TITLE
Fix remote positions missing of MirrorXY

### DIFF
--- a/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
+++ b/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
@@ -56,34 +56,14 @@ namespace UnityEditor
                     break;
                 }
             }
-            if (extendNeighbor)
-            {
-                bounds.xMin--;
-                bounds.yMin--;
-                bounds.xMax++;
-                bounds.yMax++;
-            }
-            bounds.xMin = Mathf.Min(bounds.xMin, -1);
-            bounds.yMin = Mathf.Min(bounds.yMin, -1);
-            bounds.xMax = Mathf.Max(bounds.xMax, 2);
-            bounds.yMax = Mathf.Max(bounds.yMax, 2);
-            return bounds;
+            return base.GetRuleGUIBounds(bounds, rule);
         }
 
         public override Vector2 GetMatrixSize(BoundsInt bounds)
         {
             var hexTile = tile as HexagonalRuleTile;
             Vector2 size = base.GetMatrixSize(bounds);
-
-            if (hexTile.m_FlatTop)
-            {
-                float x = size.x;
-                float y = size.y;
-                size.x = y;
-                size.y = x;
-            }
-
-            return size;
+            return hexTile.m_FlatTop ? new Vector2(size.y, size.x) : size;
         }
 
         public override void RuleMatrixOnGUI(RuleTile tile, Rect rect, BoundsInt bounds, RuleTile.TilingRule tilingRule)
@@ -158,12 +138,8 @@ namespace UnityEditor
                 {
                     Vector3Int pos = new Vector3Int(x, y, 0);
                     Vector2 offset = new Vector2(x - bounds.xMin, -y + bounds.yMax - 1);
-                    Rect r;
-
-                    if (flatTop)
-                        r = new Rect(rect.xMin + offset.y * w, rect.yMax - offset.x * h - h, w - 1, h - 1);
-                    else
-                        r = new Rect(rect.xMin + offset.x * w, rect.yMin + offset.y * h, w - 1, h - 1);
+                    Rect r = flatTop ? new Rect(rect.xMin + offset.y * w, rect.yMax - offset.x * h - h, w - 1, h - 1)
+                        : new Rect(rect.xMin + offset.x * w, rect.yMin + offset.y * h, w - 1, h - 1);
 
                     if (y % 2 != 0)
                     {
@@ -187,7 +163,6 @@ namespace UnityEditor
                     }
                     else
                     {
-                        // Center
                         RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
                         if (RuleTransformUpdate(r, tilingRule))
                         {

--- a/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
+++ b/Editor/Tiles/HexagonalRuleTile/HexagonalRuleTileEditor.cs
@@ -158,7 +158,7 @@ namespace UnityEditor
                         }
                         if (RuleNeighborUpdate(r, tilingRule, neighbors, pos))
                         {
-                            tile.UpdateRemoteRulePositions();
+                            tile.UpdateNeighborPositions();
                         }
                     }
                     else
@@ -166,7 +166,7 @@ namespace UnityEditor
                         RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
                         if (RuleTransformUpdate(r, tilingRule))
                         {
-                            tile.UpdateRemoteRulePositions();
+                            tile.UpdateNeighborPositions();
                         }
                     }
                 }

--- a/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
+++ b/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
@@ -82,7 +82,7 @@ namespace UnityEditor
                         }
                         if (RuleNeighborUpdate(r, tilingRule, neighbors, pos))
                         {
-                            tile.UpdateRemoteRulePositions();
+                            tile.UpdateNeighborPositions();
                         }
                     }
                     else
@@ -90,7 +90,7 @@ namespace UnityEditor
                         RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
                         if (RuleTransformUpdate(r, tilingRule))
                         {
-                            tile.UpdateRemoteRulePositions();
+                            tile.UpdateNeighborPositions();
                         }
                     }
                 }

--- a/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
+++ b/Editor/Tiles/IsometricRuleTile/IsometricRuleTileEditor.cs
@@ -32,16 +32,16 @@ namespace UnityEditor
             for (int y = 0; y <= bounds.size.y; y++)
             {
                 float left = rect.xMin + d * y;
-                float right = rect.xMax - d * (bounds.size.y - y);
                 float top = rect.yMin + d * y;
+                float right = rect.xMax - d * (bounds.size.y - y);
                 float bottom = rect.yMax - d * (bounds.size.y - y);
                 Handles.DrawLine(new Vector3(left, bottom), new Vector3(right, top));
             }
             for (int x = 0; x <= bounds.size.x; x++)
             {
                 float left = rect.xMin + d * x;
-                float right = rect.xMax - d * (bounds.size.x - x);
                 float top = rect.yMax - d * x;
+                float right = rect.xMax - d * (bounds.size.x - x);
                 float bottom = rect.yMin + d * (bounds.size.x - x);
                 Handles.DrawLine(new Vector3(left, bottom), new Vector3(right, top));
             }
@@ -53,8 +53,8 @@ namespace UnityEditor
             float iconSize = rect.width / (bounds.size.x + bounds.size.y);
             var rect2 = new Rect(rect);
             rect2.xMin += iconSize * 0.5f;
-            rect2.xMax -= iconSize * 0.5f;
             rect2.yMin += iconSize * 0.5f;
+            rect2.xMax -= iconSize * 0.5f;
             rect2.yMax -= iconSize * 0.5f;
             iconSize = rect2.width / (bounds.size.x + bounds.size.y - 1);
             float p = Mathf.Pow(2, 0.5f);

--- a/Editor/Tiles/RuleTile/RuleTileEditor.cs
+++ b/Editor/Tiles/RuleTile/RuleTileEditor.cs
@@ -424,7 +424,7 @@ namespace UnityEditor
                         }
                         if (RuleNeighborUpdate(r, tilingRule, neighbors, pos))
                         {
-                            tile.UpdateRemoteRulePositions();
+                            tile.UpdateNeighborPositions();
                         }
                     }
                     else
@@ -432,7 +432,7 @@ namespace UnityEditor
                         RuleTransformOnGUI(r, tilingRule.m_RuleTransform);
                         if (RuleTransformUpdate(r, tilingRule))
                         {
-                            tile.UpdateRemoteRulePositions();
+                            tile.UpdateNeighborPositions();
                         }
                     }
                 }

--- a/Editor/Tiles/RuleTile/RuleTileEditor.cs
+++ b/Editor/Tiles/RuleTile/RuleTileEditor.cs
@@ -83,7 +83,7 @@ namespace UnityEditor
             m_ReorderableList.drawHeaderCallback = OnDrawHeader;
             m_ReorderableList.drawElementCallback = OnDrawElement;
             m_ReorderableList.elementHeightCallback = GetElementHeight;
-            m_ReorderableList.onReorderCallback = ListUpdated;
+            m_ReorderableList.onChangedCallback = ListUpdated;
             m_ReorderableList.onAddCallback = OnAddElement;
         }
 

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -25,12 +25,6 @@ namespace UnityEngine
     public class HexagonalRuleTile : RuleTile
     {
 
-        /// <summary>
-        /// Returns the number of neighbors a Rule Tile can have.
-        /// </summary>
-        public int neighborCount => 6;
-
-        public override int m_RotationAngle => 60;
         public override Vector3Int[] m_NearbyNeighborPositions => new Vector3Int[] {
             new Vector3Int(-1, 1, 0),
             new Vector3Int(0, 1, 0),
@@ -123,26 +117,6 @@ namespace UnityEngine
                 location.x -= 1;
 
             return location;
-        }
-
-        /// <summary>
-        /// Returns a random transform matrix given the random transform rule.
-        /// </summary>
-        /// <param name="type">Random transform rule.</param>
-        /// <param name="original">The original transform matrix.</param>
-        /// <param name="perlinScale">The Perlin Scale factor of the Tile.</param>
-        /// <param name="position">Position of the Tile on the Tilemap.</param>
-        /// <returns>A random transform matrix.</returns>
-        protected override Matrix4x4 ApplyRandomTransform(TilingRule.Transform type, Matrix4x4 original, float perlinScale, Vector3Int position)
-        {
-            switch (type)
-            {
-                case TilingRule.Transform.Rotated:
-                    float perlin = GetPerlinValue(position, perlinScale, 200000f);
-                    int angle = Mathf.Clamp(Mathf.FloorToInt(perlin * neighborCount), 0, neighborCount - 1) * (360 / neighborCount);
-                    return Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(0f, 0f, -angle), Vector3.one);
-            }
-            return base.ApplyRandomTransform(type, original, perlinScale, position);
         }
 
         /// <summary>

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -26,18 +26,6 @@ namespace UnityEngine
     {
 
         public override int m_RotationAngle => 60;
-        public override Vector3Int[] m_NearbyNeighborPositions => new Vector3Int[] {
-            new Vector3Int(-1, 1, 0),
-            new Vector3Int(0, 1, 0),
-            new Vector3Int(-1, 0, 0),
-            new Vector3Int(1, 0, 0),
-            new Vector3Int(-1, -1, 0),
-            new Vector3Int(0, -1, 0),
-        };
-        public override bool IsNearbyNeighborPosition(Vector3Int position)
-        {
-            return (position.x >= -1 && position.x <= 0 && position.y >= -1 && position.y <= 1) || position == Vector3Int.right;
-        }
 
         private static float[] m_CosAngleArr1 = {
             Mathf.Cos(0 * Mathf.Deg2Rad),

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -135,18 +135,14 @@ namespace UnityEngine
         /// <returns>A random transform matrix.</returns>
         protected override Matrix4x4 ApplyRandomTransform(TilingRule.Transform type, Matrix4x4 original, float perlinScale, Vector3Int position)
         {
-            float perlin = GetPerlinValue(position, perlinScale, 200000f);
             switch (type)
             {
-                case TilingRule.Transform.MirrorX:
-                    return original * Matrix4x4.TRS(Vector3.zero, Quaternion.identity, new Vector3(perlin < 0.5 ? 1f : -1f, 1f, 1f));
-                case TilingRule.Transform.MirrorY:
-                    return original * Matrix4x4.TRS(Vector3.zero, Quaternion.identity, new Vector3(1f, perlin < 0.5 ? 1f : -1f, 1f));
                 case TilingRule.Transform.Rotated:
+                    float perlin = GetPerlinValue(position, perlinScale, 200000f);
                     int angle = Mathf.Clamp(Mathf.FloorToInt(perlin * neighborCount), 0, neighborCount - 1) * (360 / neighborCount);
                     return Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(0f, 0f, -angle), Vector3.one);
             }
-            return original;
+            return base.ApplyRandomTransform(type, original, perlinScale, position);
         }
 
         /// <summary>

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -25,6 +25,7 @@ namespace UnityEngine
     public class HexagonalRuleTile : RuleTile
     {
 
+        public override int m_RotationAngle => 60;
         public override Vector3Int[] m_NearbyNeighborPositions => new Vector3Int[] {
             new Vector3Int(-1, 1, 0),
             new Vector3Int(0, 1, 0),

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -257,18 +257,28 @@ namespace UnityEngine
                         // Check rule against rotations of 0, 90, 180, 270
                         if (rule.m_RuleTransform == TilingRule.Transform.Rotated)
                         {
-                            for (int angle = 0; angle < 360; angle += m_RotationAngle)
+                            for (int angle = m_RotationAngle; angle < 360; angle += m_RotationAngle)
                             {
                                 positions[GetRotatedPosition(position, angle)] = true;
                             }
                         }
-
                         // Check rule against x-axis, y-axis mirror
-                        positions[GetMirroredPosition(
-                            position,
-                            rule.m_RuleTransform == TilingRule.Transform.MirrorX || rule.m_RuleTransform == TilingRule.Transform.MirrorXY,
-                            rule.m_RuleTransform == TilingRule.Transform.MirrorY || rule.m_RuleTransform == TilingRule.Transform.MirrorXY)
-                        ] = true;
+                        else if (rule.m_RuleTransform == TilingRule.Transform.MirrorXY)
+                        {
+                            positions[GetMirroredPosition(position, true, true)] = true;
+                            positions[GetMirroredPosition(position, true, false)] = true;
+                            positions[GetMirroredPosition(position, false, true)] = true;
+                        }
+                        // Check rule against x-axis mirror
+                        else if (rule.m_RuleTransform == TilingRule.Transform.MirrorX)
+                        {
+                            positions[GetMirroredPosition(position, true, false)] = true;
+                        }
+                        // Check rule against y-axis mirror
+                        else if (rule.m_RuleTransform == TilingRule.Transform.MirrorY)
+                        {
+                            positions[GetMirroredPosition(position, false, true)] = true;
+                        }
                     }
                 }
             }
@@ -471,6 +481,7 @@ namespace UnityEngine
                     }
                 }
             }
+            // Check rule against x-axis, y-axis mirror
             else if (rule.m_RuleTransform == TilingRule.Transform.MirrorXY)
             {
                 if (RuleMatches(rule, position, tilemap, true, true))

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -43,11 +43,8 @@ namespace UnityEngine
         /// </summary>
         public Tile.ColliderType m_DefaultColliderType = Tile.ColliderType.Sprite;
 
-        /// <summary>
-        /// Returns the number of neighbors a Rule Tile can have.
-        /// </summary>
-        public virtual int m_NeighborCount => m_NearbyNeighborPositions.Length; // 8
-        public virtual int m_RotationAngle => 360 / m_NeighborCount; // 90
+        public virtual int m_RotationAngle => 90;
+        public int m_RotationCount => 360 / m_RotationAngle;
         public virtual Vector3Int[] m_NearbyNeighborPositions => new Vector3Int[] {
             new Vector3Int(-1, 1, 0),
             new Vector3Int(0, 1, 0),
@@ -546,7 +543,7 @@ namespace UnityEngine
                 case TilingRule.Transform.MirrorY:
                     return original * Matrix4x4.TRS(Vector3.zero, Quaternion.identity, new Vector3(1f, perlin < 0.5 ? 1f : -1f, 1f));
                 case TilingRule.Transform.Rotated:
-                    int angle = Mathf.Clamp(Mathf.FloorToInt(perlin * m_NeighborCount), 0, m_NeighborCount - 1) * m_RotationAngle;
+                    int angle = Mathf.Clamp(Mathf.FloorToInt(perlin * m_RotationCount), 0, m_RotationCount - 1) * m_RotationAngle;
                     return Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(0f, 0f, -angle), Vector3.one);
             }
             return original;

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -229,6 +229,8 @@ namespace UnityEngine
 
         public void UpdateNeighborPositions()
         {
+            m_CacheTilemapsNeighborPositions.Clear();
+
             HashSet<Vector3Int> positions = m_NeighborPositions;
             positions.Clear();
 

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -43,7 +43,11 @@ namespace UnityEngine
         /// </summary>
         public Tile.ColliderType m_DefaultColliderType = Tile.ColliderType.Sprite;
 
-        public virtual int m_RotationAngle => 90;
+        /// <summary>
+        /// Returns the number of neighbors a Rule Tile can have.
+        /// </summary>
+        public virtual int m_NeighborCount => m_NearbyNeighborPositions.Length; // 8
+        public virtual int m_RotationAngle => 360 / m_NeighborCount; // 90
         public virtual Vector3Int[] m_NearbyNeighborPositions => new Vector3Int[] {
             new Vector3Int(-1, 1, 0),
             new Vector3Int(0, 1, 0),
@@ -542,7 +546,7 @@ namespace UnityEngine
                 case TilingRule.Transform.MirrorY:
                     return original * Matrix4x4.TRS(Vector3.zero, Quaternion.identity, new Vector3(1f, perlin < 0.5 ? 1f : -1f, 1f));
                 case TilingRule.Transform.Rotated:
-                    int angle = Mathf.Clamp(Mathf.FloorToInt(perlin * 4), 0, 3) * 90;
+                    int angle = Mathf.Clamp(Mathf.FloorToInt(perlin * m_NeighborCount), 0, m_NeighborCount - 1) * m_RotationAngle;
                     return Matrix4x4.TRS(Vector3.zero, Quaternion.Euler(0f, 0f, -angle), Vector3.one);
             }
             return original;


### PR DESCRIPTION
Fixed some cases where the tile refresh did not refresh the affected remote tile.

https://github.com/Unity-Technologies/2d-extras/pull/148/commits/8de8e1bc648a5eb4d4ea52aee13efb4ea57dc6b1 Update:
```RefreshNearTiles()``` and ```RefreshRemoteTiles()``` are used to speed up ```RefreshTile()```. Most people don't use the 5x5 rule size. The algorithm assumes the size of the past 3x3 rule. More than 3x3 will do extra calculations to ensure that users will not be affected by the upgrade.
Now change to Caching all RuleTile neighbor positions for the Tilemap, speedup 5x5 to same as 3x3.