### PR TITLE
Fixed RuleTile instantiatedGameObject rotation/scale

### DIFF
--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -284,7 +284,9 @@ namespace UnityEngine
                 Tilemap tmpMap = tilemap.GetComponent<Tilemap>();
                 
                 var iden = Matrix4x4.identity;
-                Quaternion gameObjectQuaternion = new Quaternion();
+                Vector3 gameObjectTranslation = new Vector3();
+                Quaternion gameObjectRotation = new Quaternion();
+                Vector3 gameObjectScale = new Vector3();
 
                 foreach (TilingRule rule in m_TilingRules)
                 {
@@ -293,15 +295,17 @@ namespace UnityEngine
                     {
                         transform = tmpMap.orientationMatrix * transform;
                         
-                        // Converts the tile's rotation matrix to a quaternion to be used by the instantiated Game Object
-                        gameObjectQuaternion = Quaternion.LookRotation(new Vector3(transform.m02, transform.m12, transform.m22), new Vector3(transform.m01, transform.m11, transform.m21));
+                        // Converts the tile's translation, rotation, & scale matrix to values to be used by the instantiated Game Object
+                        gameObjectTranslation = new Vector3(transform.m03, transform.m13, transform.m23);
+                        gameObjectRotation = Quaternion.LookRotation(new Vector3(transform.m02, transform.m12, transform.m22), new Vector3(transform.m01, transform.m11, transform.m21));
+                        gameObjectScale = transform.lossyScale;
                         break;
                     }
                 }
                 
-                instantiatedGameObject.transform.localPosition = tmpMap.CellToLocalInterpolated(location + tmpMap.tileAnchor) + tmpMap.orientationMatrix.MultiplyPoint3x4(Vector3.zero);
-                instantiatedGameObject.transform.localRotation = gameObjectQuaternion;
-                instantiatedGameObject.transform.localScale = tmpMap.orientationMatrix.lossyScale;
+                instantiatedGameObject.transform.localPosition = gameObjectTranslation + tmpMap.CellToLocalInterpolated(location + tmpMap.tileAnchor);
+                instantiatedGameObject.transform.localRotation = gameObjectRotation;
+                instantiatedGameObject.transform.localScale = gameObjectScale;
             }
 
             return true;

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -282,25 +282,36 @@ namespace UnityEngine
             if (instantiatedGameObject != null)
             {
                 Tilemap tmpMap = tilemap.GetComponent<Tilemap>();
+                Matrix4x4 orientMatrix = tmpMap.orientationMatrix;
                 
                 var iden = Matrix4x4.identity;
                 Vector3 gameObjectTranslation = new Vector3();
                 Quaternion gameObjectRotation = new Quaternion();
                 Vector3 gameObjectScale = new Vector3();
-
+                
+                bool ruleMatched = false;
                 foreach (TilingRule rule in m_TilingRules)
                 {
                     Matrix4x4 transform = iden;
                     if (RuleMatches(rule, location, tilemap, ref transform))
                     {
-                        transform = tmpMap.orientationMatrix * transform;
+                        transform = orientMatrix * transform;
                         
                         // Converts the tile's translation, rotation, & scale matrix to values to be used by the instantiated Game Object
                         gameObjectTranslation = new Vector3(transform.m03, transform.m13, transform.m23);
                         gameObjectRotation = Quaternion.LookRotation(new Vector3(transform.m02, transform.m12, transform.m22), new Vector3(transform.m01, transform.m11, transform.m21));
                         gameObjectScale = transform.lossyScale;
+                        
+                        ruleMatched = true;
                         break;
                     }
+                }
+                if (!ruleMatched)
+                {
+                    // Fallback to just using the orientMatrix for the translation, rotation, & scale values.
+                    gameObjectTranslation = new Vector3(orientMatrix.m03, orientMatrix.m13, orientMatrix.m23);
+                    gameObjectRotation = Quaternion.LookRotation(new Vector3(orientMatrix.m02, orientMatrix.m12, orientMatrix.m22), new Vector3(orientMatrix.m01, orientMatrix.m11, orientMatrix.m21));
+                    gameObjectScale = orientMatrix.lossyScale;
                 }
                 
                 instantiatedGameObject.transform.localPosition = gameObjectTranslation + tmpMap.CellToLocalInterpolated(location + tmpMap.tileAnchor);

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -281,6 +281,8 @@ namespace UnityEngine
         {
             if (instantiatedGameObject != null)
             {
+                Tilemap tmpMap = tilemap.GetComponent<Tilemap>();
+                
                 var iden = Matrix4x4.identity;
                 Quaternion gameObjectQuaternion = new Quaternion();
 
@@ -289,15 +291,17 @@ namespace UnityEngine
                     Matrix4x4 transform = iden;
                     if (RuleMatches(rule, location, tilemap, ref transform))
                     {
+                        transform = tmpMap.orientationMatrix * transform;
+                        
                         // Converts the tile's rotation matrix to a quaternion to be used by the instantiated Game Object
                         gameObjectQuaternion = Quaternion.LookRotation(new Vector3(transform.m02, transform.m12, transform.m22), new Vector3(transform.m01, transform.m11, transform.m21));
                         break;
                     }
                 }
-
-                Tilemap tmpMap = tilemap.GetComponent<Tilemap>();
-                instantiatedGameObject.transform.position = tmpMap.LocalToWorld(tmpMap.CellToLocalInterpolated(location + tmpMap.tileAnchor));
-                instantiatedGameObject.transform.rotation = gameObjectQuaternion;
+                
+                instantiatedGameObject.transform.localPosition = tmpMap.CellToLocalInterpolated(location + tmpMap.tileAnchor) + tmpMap.orientationMatrix.MultiplyPoint3x4(Vector3.zero);
+                instantiatedGameObject.transform.localRotation = gameObjectQuaternion;
+                instantiatedGameObject.transform.localScale = tmpMap.orientationMatrix.lossyScale;
             }
 
             return true;


### PR DESCRIPTION
Performed fixes to the math in `RuleTile`'s `StartUp()` method so that instantiated `GameObject`s match the rotation and scale transformations of sprites (done internally by Unity's `SpriteRenderer`).  The desired intent here is that if you create a `RuleTile` with 3D `GameObject`s and 2D `Sprite`s that are visually a flattened version of the 3D art _(imagine 3D walls in a maze, and 2D sprites showing the top-down outlines of the walls)_, they should **always** match up with each other in the Unity Editor and Player.

* Added application of the `Tilemap`'s `orientationMatrix` to the `transform` matrix.  This is necessary for `instantiatedGameObject` to be rotated correctly when using any of the `Tilemap` `orientation` & `Grid` `cellSwizzle` modes beyond the default `.XY` & `.XYZ`.
* Now setting the `instantiatedGameObject.transform`'s `localPosition` instead of using the `Tilemap`'s `LocalToWorld()` method for (world) `position`.  This fixes a variety of issues that occur when the `Tilemap` or `Grid`'s GameObject `Transform` (or any parents) have a non-identity rotation or scale.
* Likewise, now setting the `instantiatedGameObject.transform`'s `localRotation` instead of setting (world) `rotation` unconverted.  _(Like above, fixes a variety of issues that occur when the `Tilemap` or `Grid`'s GameObject `Transform` (or any parents) have a non-identity rotation or scale.)_
* Adding the calculated translation from the `orientationMatrix` to  the `instantiatedGameObject.transform.localPosition`.  This enables the `Tilemap`'s _Orientation: Custom: Position_ editor values to apply properly.
* Also, setting the `instantiatedGameObject.transform`'s `localScale` to the Tilemap's `orientationMatrix.lossyScale`.  This ensures that _Orientation: Custom: Scale_ editor value affects the GameObjects.  Also, if a parent Transform has a scale in any axis, the `instantiatedGameObject`'s scale ends up with an inverse value of the parent— this fixes that too.

Again, the end result of all of the above modifications/fixes are to match what Unity's `SpriteRenderer` does— that's the ground truth I've thoroughly tested these calculations against.