### PR TITLE
[CustomRuleTile] Support HideInInspector, DontOverride attributes

### DIFF
--- a/Editor/Tiles/RuleOverrideTile/AdvancedRuleOverrideTileEditor.cs
+++ b/Editor/Tiles/RuleOverrideTile/AdvancedRuleOverrideTileEditor.cs
@@ -15,7 +15,6 @@ namespace UnityEditor
         ReorderableList m_RuleList;
 
         static float k_DefaultElementHeight { get { return RuleTileEditor.k_DefaultElementHeight; } }
-        static float k_PaddingBetweenRules { get { return RuleTileEditor.k_PaddingBetweenRules; } }
         static float k_SingleLineHeight { get { return RuleTileEditor.k_SingleLineHeight; } }
         static float k_LabelWidth { get { return RuleTileEditor.k_LabelWidth; } }
 
@@ -52,12 +51,12 @@ namespace UnityEditor
             m_RuleList.DoLayoutList();
         }
 
-        void DrawRulesHeader(Rect rect)
+        public void DrawRulesHeader(Rect rect)
         {
             GUI.Label(rect, "Tiling Rules", EditorStyles.label);
         }
 
-        void DrawRuleElement(Rect rect, int index, bool selected, bool focused)
+        public void DrawRuleElement(Rect rect, int index, bool selected, bool focused)
         {
             RuleTile.TilingRule originalRule = m_Rules[index].Key;
             RuleTile.TilingRuleOutput overrideRule = m_Rules[index].Value;
@@ -93,7 +92,7 @@ namespace UnityEditor
             }
         }
 
-        void DrawRule(Rect rect, RuleTile.TilingRuleOutput rule, bool isOverride, RuleTile.TilingRule originalRule, bool isMissing)
+        public void DrawRule(Rect rect, RuleTile.TilingRuleOutput rule, bool isOverride, RuleTile.TilingRule originalRule, bool isMissing)
         {
             if (isMissing)
             {
@@ -129,7 +128,7 @@ namespace UnityEditor
             }
         }
 
-        float GetRuleElementHeight(int index)
+        public float GetRuleElementHeight(int index)
         {
             var originalRule = m_Rules[index].Key;
             var overrideRule = m_Rules[index].Value;

--- a/Editor/Tiles/RuleOverrideTile/AdvancedRuleOverrideTileEditor.cs
+++ b/Editor/Tiles/RuleOverrideTile/AdvancedRuleOverrideTileEditor.cs
@@ -13,6 +13,7 @@ namespace UnityEditor
 
         List<KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRuleOutput>> m_Rules = new List<KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRuleOutput>>();
         ReorderableList m_RuleList;
+        int m_MissingOriginalRuleIndex;
 
         static float k_DefaultElementHeight { get { return RuleTileEditor.k_DefaultElementHeight; } }
         static float k_SingleLineHeight { get { return RuleTileEditor.k_SingleLineHeight; } }
@@ -44,9 +45,8 @@ namespace UnityEditor
 
             DrawCustomFields();
 
-            m_Rules.Clear();
             if (overrideTile.m_Tile)
-                overrideTile.GetOverrides(m_Rules);
+                overrideTile.GetOverrides(m_Rules, ref m_MissingOriginalRuleIndex);
 
             m_RuleList.DoLayoutList();
         }
@@ -60,7 +60,7 @@ namespace UnityEditor
         {
             RuleTile.TilingRule originalRule = m_Rules[index].Key;
             RuleTile.TilingRuleOutput overrideRule = m_Rules[index].Value;
-            bool isMissing = index >= overrideTile.m_MissingTilingRuleIndex;
+            bool isMissing = index >= m_MissingOriginalRuleIndex;
 
             DrawToggleInternal(new Rect(rect.xMin, rect.yMin, 16, rect.height));
             DrawRuleInternal(new Rect(rect.xMin + 16, rect.yMin, rect.width - 16, rect.height));
@@ -134,7 +134,7 @@ namespace UnityEditor
             var overrideRule = m_Rules[index].Value;
             float height = overrideRule != null ? ruleTileEditor.GetElementHeight(overrideRule) : ruleTileEditor.GetElementHeight(originalRule);
 
-            bool isMissing = index >= overrideTile.m_MissingTilingRuleIndex;
+            bool isMissing = index >= m_MissingOriginalRuleIndex;
             if (isMissing)
                 height += 16;
 

--- a/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
+++ b/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
@@ -27,14 +27,14 @@ namespace UnityEditor
         RuleTileEditor m_RuleTileEditor;
         RuleTile m_RuleTileEditorTarget;
 
-        List<KeyValuePair<Sprite, Sprite>> m_Sprites = new List<KeyValuePair<Sprite, Sprite>>();
-        List<KeyValuePair<GameObject, GameObject>> m_GameObjects = new List<KeyValuePair<GameObject, GameObject>>();
-        ReorderableList m_SpriteList;
-        ReorderableList m_GameObjectList;
+        public List<KeyValuePair<Sprite, Sprite>> m_Sprites = new List<KeyValuePair<Sprite, Sprite>>();
+        public List<KeyValuePair<GameObject, GameObject>> m_GameObjects = new List<KeyValuePair<GameObject, GameObject>>();
+        public ReorderableList m_SpriteList;
+        public ReorderableList m_GameObjectList;
 
-        static float k_SpriteElementHeight = 48;
-        static float k_GameObjectElementHeight = 16;
-        static float k_PaddingBetweenRules = 4;
+        public static float k_SpriteElementHeight = 48;
+        public static float k_GameObjectElementHeight = 16;
+        public static float k_PaddingBetweenRules = 4;
 
         public virtual void OnEnable()
         {
@@ -104,7 +104,7 @@ namespace UnityEditor
             }
         }
 
-        void DrawSpriteListHeader(Rect rect)
+        public void DrawSpriteListHeader(Rect rect)
         {
             float xMax = rect.xMax;
             rect.xMax = rect.xMax / 2.0f;
@@ -114,7 +114,7 @@ namespace UnityEditor
             GUI.Label(rect, "Override Sprite", EditorStyles.label);
         }
 
-        void DrawGameObjectListHeader(Rect rect)
+        public void DrawGameObjectListHeader(Rect rect)
         {
             float xMax = rect.xMax;
             rect.xMax = rect.xMax / 2.0f;
@@ -124,7 +124,7 @@ namespace UnityEditor
             GUI.Label(rect, "Override GameObject", EditorStyles.label);
         }
 
-        float GetSpriteElementHeight(int index)
+        public float GetSpriteElementHeight(int index)
         {
             float height = k_SpriteElementHeight + k_PaddingBetweenRules;
 
@@ -135,7 +135,7 @@ namespace UnityEditor
             return height;
         }
 
-        float GetGameObjectElementHeight(int index)
+        public float GetGameObjectElementHeight(int index)
         {
             float height = k_GameObjectElementHeight + k_PaddingBetweenRules;
 
@@ -146,7 +146,7 @@ namespace UnityEditor
             return height;
         }
 
-        void DrawSpriteElement(Rect rect, int index, bool selected, bool focused)
+        public void DrawSpriteElement(Rect rect, int index, bool selected, bool focused)
         {
             bool isMissing = index >= overrideTile.m_MissingSpriteIndex;
             if (isMissing)
@@ -174,7 +174,7 @@ namespace UnityEditor
                 m_Sprites[index] = new KeyValuePair<Sprite, Sprite>(originalSprite, overrideSprite);
         }
 
-        void DrawGameObjectElement(Rect rect, int index, bool selected, bool focused)
+        public void DrawGameObjectElement(Rect rect, int index, bool selected, bool focused)
         {
             bool isMissing = index >= overrideTile.m_MissingSpriteIndex;
             if (isMissing)

--- a/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
+++ b/Editor/Tiles/RuleOverrideTile/RuleOverrideTileEditor.cs
@@ -249,7 +249,7 @@ namespace UnityEditor
             if (ruleTileEditor)
             {
                 ruleTileEditor.target.hideFlags = HideFlags.None;
-                ruleTileEditor.DrawCustomFields();
+                ruleTileEditor.DrawCustomFields(true);
                 ruleTileEditor.target.hideFlags = HideFlags.NotEditable;
             }
         }

--- a/Editor/Tiles/RuleTile/RuleTileEditor.cs
+++ b/Editor/Tiles/RuleTile/RuleTileEditor.cs
@@ -69,7 +69,7 @@ namespace UnityEditor
         }
 
         public RuleTile tile => target as RuleTile;
-        private ReorderableList m_ReorderableList;
+        public ReorderableList m_ReorderableList;
         public bool extendNeighbor;
 
         public PreviewRenderUtility m_PreviewUtility;
@@ -122,7 +122,6 @@ namespace UnityEditor
                     rule.m_Id++;
                 usedIdSet.Add(rule.m_Id);
             }
-            SaveTile();
         }
 
         private float GetElementHeight(int index)
@@ -176,12 +175,9 @@ namespace UnityEditor
             Rect matrixRect = new Rect(rect.xMax - matrixSize.x - spriteRect.width - 10f, yPos, matrixSize.x, matrixSize.y);
             Rect inspectorRect = new Rect(rect.xMin, yPos, rect.width - matrixSize.x - spriteRect.width - 20f, height);
 
-            EditorGUI.BeginChangeCheck();
             RuleInspectorOnGUI(inspectorRect, rule);
             RuleMatrixOnGUI(tile, matrixRect, bounds, rule);
             SpriteOnGUI(spriteRect, rule);
-            if (EditorGUI.EndChangeCheck())
-                SaveTile();
         }
 
         private void OnAddElement(ReorderableList list)
@@ -249,24 +245,25 @@ namespace UnityEditor
         public override void OnInspectorGUI()
         {
             EditorGUI.BeginChangeCheck();
+
             tile.m_DefaultSprite = EditorGUILayout.ObjectField("Default Sprite", tile.m_DefaultSprite, typeof(Sprite), false) as Sprite;
             tile.m_DefaultGameObject = EditorGUILayout.ObjectField("Default Game Object", tile.m_DefaultGameObject, typeof(GameObject), false) as GameObject;
             tile.m_DefaultColliderType = (Tile.ColliderType)EditorGUILayout.EnumPopup("Default Collider", tile.m_DefaultColliderType);
-            if (EditorGUI.EndChangeCheck())
-                SaveTile();
 
-            DrawCustomFields();
+            DrawCustomFields(false);
 
             EditorGUILayout.Space();
 
             if (m_ReorderableList != null)
                 m_ReorderableList.DoLayoutList();
+
+            if (EditorGUI.EndChangeCheck())
+                SaveTile();
         }
 
-        public void DrawCustomFields()
+        public void DrawCustomFields(bool isOverrideInstance)
         {
-            var customFields = tile.GetType().GetFields()
-                .Where(field => typeof(RuleTile).GetField(field.Name) == null);
+            var customFields = tile.GetCustomFields(isOverrideInstance);
 
             serializedObject.Update();
             EditorGUI.BeginChangeCheck();
@@ -475,7 +472,7 @@ namespace UnityEditor
 
         public virtual void SpriteOnGUI(Rect rect, RuleTile.TilingRuleOutput tilingRule)
         {
-            tilingRule.m_Sprites[0] = EditorGUI.ObjectField(new Rect(rect.xMax - rect.height, rect.yMin, rect.height, rect.height), tilingRule.m_Sprites[0], typeof(Sprite), false) as Sprite;
+            tilingRule.m_Sprites[0] = EditorGUI.ObjectField(rect, tilingRule.m_Sprites[0], typeof(Sprite), false) as Sprite;
         }
 
         public void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRuleOutput tilingRule)

--- a/Editor/Tiles/RuleTile/RuleTileEditor.cs
+++ b/Editor/Tiles/RuleTile/RuleTileEditor.cs
@@ -82,7 +82,7 @@ namespace UnityEditor
         public const float k_SingleLineHeight = 16f;
         public const float k_LabelWidth = 80f;
 
-        public void OnEnable()
+        public virtual void OnEnable()
         {
             m_ReorderableList = new ReorderableList(tile.m_TilingRules, typeof(RuleTile.TilingRule), true, true, true, true);
             m_ReorderableList.drawHeaderCallback = OnDrawHeader;
@@ -92,7 +92,7 @@ namespace UnityEditor
             m_ReorderableList.onAddCallback = OnAddElement;
         }
 
-        public void OnDisable()
+        public virtual void OnDisable()
         {
             DestroyPreview();
         }
@@ -113,7 +113,7 @@ namespace UnityEditor
             return bounds;
         }
 
-        private void ListUpdated(ReorderableList list)
+        public void ListUpdated(ReorderableList list)
         {
             HashSet<int> usedIdSet = new HashSet<int>();
             foreach (var rule in tile.m_TilingRules)
@@ -124,7 +124,7 @@ namespace UnityEditor
             }
         }
 
-        private float GetElementHeight(int index)
+        public float GetElementHeight(int index)
         {
             RuleTile.TilingRule rule = tile.m_TilingRules[index];
             return GetElementHeight(rule);
@@ -162,7 +162,7 @@ namespace UnityEditor
             return new Vector2(bounds.size.x * k_SingleLineHeight, bounds.size.y * k_SingleLineHeight);
         }
 
-        protected virtual void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
+        public virtual void OnDrawElement(Rect rect, int index, bool isactive, bool isfocused)
         {
             RuleTile.TilingRule rule = tile.m_TilingRules[index];
             BoundsInt bounds = GetRuleGUIBounds(rule.GetBounds(), rule);
@@ -180,7 +180,7 @@ namespace UnityEditor
             SpriteOnGUI(spriteRect, rule);
         }
 
-        private void OnAddElement(ReorderableList list)
+        public void OnAddElement(ReorderableList list)
         {
             RuleTile.TilingRule rule = new RuleTile.TilingRule();
             rule.m_Output = RuleTile.TilingRule.OutputSprite.Single;
@@ -226,7 +226,7 @@ namespace UnityEditor
             return overrideTiles;
         }
 
-        private void OnDrawHeader(Rect rect)
+        public void OnDrawHeader(Rect rect)
         {
             GUI.Label(rect, "Tiling Rules");
 
@@ -409,7 +409,7 @@ namespace UnityEditor
             return rect.Contains(Event.current.mousePosition);
         }
 
-        private static int GetMouseChange()
+        public static int GetMouseChange()
         {
             return Event.current.button == 1 ? -1 : 1;
         }
@@ -579,7 +579,7 @@ namespace UnityEditor
             m_PreviewTilemaps[3].SetTile(new Vector3Int(1, -2, 0), tile);
         }
 
-        private void DestroyPreview()
+        public void DestroyPreview()
         {
             if (m_PreviewUtility != null)
             {
@@ -610,7 +610,7 @@ namespace UnityEditor
             return base.RenderStaticPreview(assetPath, subAssets, width, height);
         }
 
-        private static Type GetType(string TypeName)
+        public static Type GetType(string TypeName)
         {
             var type = Type.GetType(TypeName);
             if (type != null)
@@ -642,7 +642,7 @@ namespace UnityEditor
             return null;
         }
 
-        private static Texture2D Base64ToTexture(string base64)
+        public static Texture2D Base64ToTexture(string base64)
         {
             Texture2D t = new Texture2D(1, 1);
             t.hideFlags = HideFlags.HideAndDontSave;
@@ -658,7 +658,7 @@ namespace UnityEditor
         }
 
         [MenuItem("CONTEXT/RuleTile/Copy All Rules")]
-        private static void CopyAllRules(MenuCommand item)
+        public static void CopyAllRules(MenuCommand item)
         {
             RuleTile tile = item.context as RuleTile;
             if (tile == null)
@@ -671,7 +671,7 @@ namespace UnityEditor
         }
 
         [MenuItem("CONTEXT/RuleTile/Paste Rules")]
-        private static void PasteRules(MenuCommand item)
+        public static void PasteRules(MenuCommand item)
         {
             RuleTile tile = item.context as RuleTile;
             if (tile == null)

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -63,7 +63,7 @@ namespace UnityEngine
         /// <summary>
         /// Whether this is a flat top Hexagonal Tile
         /// </summary>
-        public bool m_FlatTop;
+        [DontOverride] public bool m_FlatTop;
 
         static float m_TilemapToWorldYScale = Mathf.Pow(1 - Mathf.Pow(0.5f, 2f), 0.5f);
 

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -88,7 +88,7 @@ namespace UnityEngine
             return tilemapPosition;
         }
 
-        protected override Vector3Int GetOffsetPosition(Vector3Int location, Vector3Int offset)
+        public override Vector3Int GetOffsetPosition(Vector3Int location, Vector3Int offset)
         {
             Vector3Int position = location + offset;
 
@@ -98,7 +98,7 @@ namespace UnityEngine
             return position;
         }
 
-        protected override Vector3Int GetOffsetPositionReverse(Vector3Int position, Vector3Int offset)
+        public override Vector3Int GetOffsetPositionReverse(Vector3Int position, Vector3Int offset)
         {
             Vector3Int location = position - offset;
 
@@ -114,7 +114,7 @@ namespace UnityEngine
         /// <param name="position">Original position of Tile.</param>
         /// <param name="rotation">Rotation in degrees.</param>
         /// <returns>Rotated position of Tile.</returns>
-        protected override Vector3Int GetRotatedPosition(Vector3Int position, int rotation)
+        public override Vector3Int GetRotatedPosition(Vector3Int position, int rotation)
         {
             if (rotation != 0)
             {
@@ -148,7 +148,7 @@ namespace UnityEngine
         /// <param name="mirrorX">Mirror in the X Axis.</param>
         /// <param name="mirrorY">Mirror in the Y Axis.</param>
         /// <returns>Mirrored position of Tile.</returns>
-        protected override Vector3Int GetMirroredPosition(Vector3Int position, bool mirrorX, bool mirrorY)
+        public override Vector3Int GetMirroredPosition(Vector3Int position, bool mirrorX, bool mirrorY)
         {
             if (mirrorX || mirrorY)
             {

--- a/Runtime/Tiles/RuleOverrideTile/AdvancedRuleOverrideTile.cs
+++ b/Runtime/Tiles/RuleOverrideTile/AdvancedRuleOverrideTile.cs
@@ -54,7 +54,6 @@ namespace UnityEngine.Tilemaps
         /// A list of TilingRule Overrides
         /// </summary>
         public List<RuleTile.TilingRuleOutput> m_OverrideTilingRules = new List<RuleTile.TilingRuleOutput>();
-        [NonSerialized] public int m_MissingTilingRuleIndex = -1;
 
         /// <summary>
         /// Applies overrides to this
@@ -75,7 +74,7 @@ namespace UnityEngine.Tilemaps
         /// </summary>
         /// <param name="overrides">A list of overrides to fill</param>
         /// <exception cref="ArgumentNullException">The input overrides list is not valid</exception>
-        public void GetOverrides(List<KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRuleOutput>> overrides)
+        public void GetOverrides(List<KeyValuePair<RuleTile.TilingRule, RuleTile.TilingRuleOutput>> overrides, ref int validCount)
         {
             if (overrides == null)
                 throw new System.ArgumentNullException("overrides");
@@ -91,7 +90,7 @@ namespace UnityEngine.Tilemaps
                 }
             }
 
-            m_MissingTilingRuleIndex = overrides.Count;
+            validCount = overrides.Count;
 
             foreach (var overrideRule in m_OverrideTilingRules)
             {

--- a/Runtime/Tiles/RuleOverrideTile/AdvancedRuleOverrideTile.cs
+++ b/Runtime/Tiles/RuleOverrideTile/AdvancedRuleOverrideTile.cs
@@ -39,8 +39,8 @@ namespace UnityEngine.Tilemaps
                 }
                 if (value != null)
                 {
-                    var overrideRule = new RuleTile.TilingRuleOutput();
-                    CopyTilingRule(value, overrideRule);
+                    var json = JsonUtility.ToJson(value);
+                    var overrideRule = JsonUtility.FromJson<RuleTile.TilingRuleOutput>(json);
                     m_OverrideTilingRules.Add(overrideRule);
                 }
             }
@@ -108,21 +108,21 @@ namespace UnityEngine.Tilemaps
             if (!m_Tile || !m_InstanceTile)
                 return;
 
+            PrepareOverride();
+
             var tile = m_InstanceTile;
 
             tile.m_DefaultSprite = m_DefaultSprite;
             tile.m_DefaultGameObject = m_DefaultGameObject;
             tile.m_DefaultColliderType = m_DefaultColliderType;
-            tile.m_TilingRules.Clear();
 
-            foreach (var originalRule in m_Tile.m_TilingRules)
+            foreach (var rule in tile.m_TilingRules)
             {
-                var overrideRule = this[originalRule];
-                var instanceRule = new RuleTile.TilingRule();
-                CopyTilingRule(originalRule, instanceRule);
+                var overrideRule = this[rule];
                 if (overrideRule != null)
-                    CopyTilingRule(overrideRule, instanceRule);
-                tile.m_TilingRules.Add(instanceRule);
+                {
+                    JsonUtility.FromJsonOverwrite(JsonUtility.ToJson(overrideRule), rule);
+                }
             }
         }
     }

--- a/Runtime/Tiles/RuleOverrideTile/RuleOverrideTile.cs
+++ b/Runtime/Tiles/RuleOverrideTile/RuleOverrideTile.cs
@@ -135,8 +135,6 @@ namespace UnityEngine.Tilemaps
         /// Returns the Rule Tile for retrieving TileData
         /// </summary>
         [HideInInspector] public RuleTile m_InstanceTile;
-        [NonSerialized] public int m_MissingSpriteIndex = -1;
-        [NonSerialized] public int m_MissingGameObjectIndex = -1;
 
         /// <summary>
         /// Applies overrides to this
@@ -171,7 +169,7 @@ namespace UnityEngine.Tilemaps
         /// </summary>
         /// <param name="overrides">A list of overrides to fill</param>
         /// <exception cref="ArgumentNullException">The input overrides list is not valid</exception>
-        public void GetOverrides(List<KeyValuePair<Sprite, Sprite>> overrides)
+        public void GetOverrides(List<KeyValuePair<Sprite, Sprite>> overrides, ref int validCount)
         {
             if (overrides == null)
                 throw new System.ArgumentNullException("overrides");
@@ -191,7 +189,7 @@ namespace UnityEngine.Tilemaps
                             originalSprites.Add(sprite);
             }
 
-            m_MissingSpriteIndex = originalSprites.Count;
+            validCount = originalSprites.Count;
 
             foreach (var pair in m_Sprites)
                 if (!originalSprites.Contains(pair.m_OriginalSprite))
@@ -206,7 +204,7 @@ namespace UnityEngine.Tilemaps
         /// </summary>
         /// <param name="overrides">A list of overrides to fill</param>
         /// <exception cref="ArgumentNullException">The input overrides list is not valid</exception>
-        public void GetOverrides(List<KeyValuePair<GameObject, GameObject>> overrides)
+        public void GetOverrides(List<KeyValuePair<GameObject, GameObject>> overrides, ref int validCount)
         {
             if (overrides == null)
                 throw new System.ArgumentNullException("overrides");
@@ -225,7 +223,7 @@ namespace UnityEngine.Tilemaps
                         originalGameObjects.Add(rule.m_GameObject);
             }
 
-            m_MissingGameObjectIndex = originalGameObjects.Count;
+            validCount = originalGameObjects.Count;
 
             foreach (var pair in m_GameObjects)
                 if (!originalGameObjects.Contains(pair.m_OriginalGameObject))

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -368,7 +368,7 @@ namespace UnityEngine
         /// <param name="scale">The Perlin Scale factor of the Tile.</param>
         /// <param name="offset">Offset of the Tile on the Tilemap.</param>
         /// <returns>A Perlin Noise value based on the given inputs.</returns>
-        protected static float GetPerlinValue(Vector3Int position, float scale, float offset)
+        public static float GetPerlinValue(Vector3Int position, float scale, float offset)
         {
             return Mathf.PerlinNoise((position.x + offset) * scale, (position.y + offset) * scale);
         }
@@ -504,7 +504,7 @@ namespace UnityEngine
         /// <param name="tilemap">The tilemap to match with.</param>
         /// <param name="transform">A transform matrix which will match the Rule.</param>
         /// <returns>True if there is a match, False if not.</returns>
-        protected virtual bool RuleMatches(TilingRule rule, Vector3Int position, ITilemap tilemap, ref Matrix4x4 transform)
+        public virtual bool RuleMatches(TilingRule rule, Vector3Int position, ITilemap tilemap, ref Matrix4x4 transform)
         {
             if (RuleMatches(rule, position, tilemap, 0))
             {
@@ -573,7 +573,7 @@ namespace UnityEngine
         /// <param name="perlinScale">The Perlin Scale factor of the Tile.</param>
         /// <param name="position">Position of the Tile on the Tilemap.</param>
         /// <returns>A random transform matrix.</returns>
-        protected virtual Matrix4x4 ApplyRandomTransform(TilingRule.Transform type, Matrix4x4 original, float perlinScale, Vector3Int position)
+        public virtual Matrix4x4 ApplyRandomTransform(TilingRule.Transform type, Matrix4x4 original, float perlinScale, Vector3Int position)
         {
             float perlin = GetPerlinValue(position, perlinScale, 200000f);
             switch (type)
@@ -626,7 +626,7 @@ namespace UnityEngine
         /// <param name="tilemap">Tilemap to match.</param>
         /// <param name="angle">Rotation angle for matching.</param>
         /// <returns>True if there is a match, False if not.</returns>
-        protected bool RuleMatches(TilingRule rule, Vector3Int position, ITilemap tilemap, int angle)
+        public bool RuleMatches(TilingRule rule, Vector3Int position, ITilemap tilemap, int angle)
         {
             for (int i = 0; i < rule.m_Neighbors.Count && i < rule.m_NeighborPositions.Count; i++)
             {
@@ -649,7 +649,7 @@ namespace UnityEngine
         /// <param name="mirrorX">Mirror X Axis for matching.</param>
         /// <param name="mirrorY">Mirror Y Axis for matching.</param>
         /// <returns>True if there is a match, False if not.</returns>
-        protected bool RuleMatches(TilingRule rule, Vector3Int position, ITilemap tilemap, bool mirrorX, bool mirrorY)
+        public bool RuleMatches(TilingRule rule, Vector3Int position, ITilemap tilemap, bool mirrorX, bool mirrorY)
         {
             for (int i = 0; i < rule.m_Neighbors.Count && i < rule.m_NeighborPositions.Count; i++)
             {
@@ -670,7 +670,7 @@ namespace UnityEngine
         /// <param name="position">Original position of Tile.</param>
         /// <param name="rotation">Rotation in degrees.</param>
         /// <returns>Rotated position of Tile.</returns>
-        protected virtual Vector3Int GetRotatedPosition(Vector3Int position, int rotation)
+        public virtual Vector3Int GetRotatedPosition(Vector3Int position, int rotation)
         {
             switch (rotation)
             {
@@ -693,7 +693,7 @@ namespace UnityEngine
         /// <param name="mirrorX">Mirror in the X Axis.</param>
         /// <param name="mirrorY">Mirror in the Y Axis.</param>
         /// <returns>Mirrored position of Tile.</returns>
-        protected virtual Vector3Int GetMirroredPosition(Vector3Int position, bool mirrorX, bool mirrorY)
+        public virtual Vector3Int GetMirroredPosition(Vector3Int position, bool mirrorX, bool mirrorY)
         {
             if (mirrorX)
                 position.x *= -1;
@@ -702,12 +702,12 @@ namespace UnityEngine
             return position;
         }
 
-        protected virtual Vector3Int GetOffsetPosition(Vector3Int location, Vector3Int offset)
+        public virtual Vector3Int GetOffsetPosition(Vector3Int location, Vector3Int offset)
         {
             return location + offset;
         }
 
-        protected virtual Vector3Int GetOffsetPositionReverse(Vector3Int position, Vector3Int offset)
+        public virtual Vector3Int GetOffsetPositionReverse(Vector3Int position, Vector3Int offset)
         {
             return position - offset;
         }


### PR DESCRIPTION
## Changes:
- Support [HideInInspector] to custom fields
- Add [DontOverride] attribute for custom fields
- Make RuleTile Api public

Sometime custom field is use to control the tiling rules(like HexagonalRuleTile.m_FlatTop), it should not editable in RuleOverrideTile. Use [DontOverride] can make the field hidden in RuleOverrideTile.