### PR TITLE
Option to Create Tiles and Brushes grouped on 2D Extras

### DIFF
--- a/Editor/Brushes/PrefabBrushes/PrefabBrush/PrefabBrush.cs
+++ b/Editor/Brushes/PrefabBrushes/PrefabBrush/PrefabBrush.cs
@@ -5,7 +5,7 @@ namespace UnityEditor.Tilemaps
     /// <summary>
     /// This Brush instances and places a selected prefab onto the targeted location and parents the instanced object to the paint target.
     /// </summary>
-    [CreateAssetMenu(fileName = "Prefab brush", menuName = "Brushes/Prefab brush")]
+    [CreateAssetMenu(fileName = "Prefab brush", menuName = "2D Extras/Brushes/Prefab brush", order = 359)]
     [CustomGridBrush(false, true, false, "Prefab Brush")]
     public class PrefabBrush : BasePrefabBrush
     {

--- a/Editor/Brushes/PrefabBrushes/PrefabRandomBrush/PrefabRandomBrush.cs
+++ b/Editor/Brushes/PrefabBrushes/PrefabRandomBrush/PrefabRandomBrush.cs
@@ -5,7 +5,7 @@ namespace UnityEditor.Tilemaps
     /// <summary>
     /// This Brush instances and places a randomly selected Prefabs onto the targeted location and parents the instanced object to the paint target. Use this as an example to quickly place an assorted type of GameObjects onto structured locations.
     /// </summary>
-    [CreateAssetMenu(fileName = "Prefab Random brush", menuName = "Brushes/Prefab Random brush")]
+    [CreateAssetMenu(fileName = "Prefab Random brush", menuName = "2D Extras/Brushes/Prefab Random brush", order = 359)]
     [CustomGridBrush(false, true, false, "Prefab Random Brush")]
     public class PrefabRandomBrush : BasePrefabBrush
     {

--- a/Editor/Brushes/RandomBrush/RandomBrush.cs
+++ b/Editor/Brushes/RandomBrush/RandomBrush.cs
@@ -11,7 +11,7 @@ namespace UnityEditor.Tilemaps
     /// Use this as an example to create brushes which store specific data per brush and to make brushes which randomize behaviour.
     /// </summary>
     [CustomGridBrush(false, false, false, "Random Brush")]
-    [CreateAssetMenu(fileName = "New Random Brush", menuName = "Brushes/Random Brush")]
+    [CreateAssetMenu(fileName = "New Random Brush", menuName = "2D Extras/Brushes/Random Brush", order = 359)]
     public class RandomBrush : GridBrush
     {
         internal struct SizeEnumerator : IEnumerator<Vector3Int>

--- a/Runtime/Tiles/AnimatedTile/AnimatedTile.cs
+++ b/Runtime/Tiles/AnimatedTile/AnimatedTile.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.Tilemaps
     /// Animated Tiles are tiles which run through and display a list of sprites in sequence.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Animated Tile", menuName = "Tiles/Animated Tile")]
+    [CreateAssetMenu(fileName = "New Animated Tile", menuName = "2D Extras/Tiles/Animated Tile", order = 359)]
     public class AnimatedTile : TileBase
     {
         /// <summary>

--- a/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
+++ b/Runtime/Tiles/HexagonalRuleTile/HexagonalRuleTile.cs
@@ -21,7 +21,7 @@ namespace UnityEngine
     /// Use this for Hexagonal Grids.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Hexagonal Rule Tile", menuName = "Tiles/Hexagonal Rule Tile")]
+    [CreateAssetMenu(fileName = "New Hexagonal Rule Tile", menuName = "2D Extras/Tiles/Hexagonal Rule Tile", order = 359)]
     public class HexagonalRuleTile : RuleTile
     {
 

--- a/Runtime/Tiles/IsometricRuleTile/IsometricRuleTile.cs
+++ b/Runtime/Tiles/IsometricRuleTile/IsometricRuleTile.cs
@@ -21,7 +21,7 @@ namespace UnityEngine
     /// Use this for Isometric Grids.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Isometric Rule Tile", menuName = "Tiles/Isometric Rule Tile")]
+    [CreateAssetMenu(fileName = "New Isometric Rule Tile", menuName = "2D Extras/Tiles/Isometric Rule Tile", order = 359)]
     public class IsometricRuleTile : RuleTile
     {
         // This has no differences with the RuleTile

--- a/Runtime/Tiles/PipelineTile/PipelineTile.cs
+++ b/Runtime/Tiles/PipelineTile/PipelineTile.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.Tilemaps
     /// Pipeline Tiles are tiles which take into consideration its orthogonal neighboring tiles and displays a sprite depending on whether the neighboring tile is the same tile.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Pipeline Tile", menuName = "Tiles/Pipeline Tile")]
+    [CreateAssetMenu(fileName = "New Pipeline Tile", menuName = "2D Extras/Tiles/Pipeline Tile", order = 359)]
     public class PipelineTile : TileBase
     {
         /// <summary>

--- a/Runtime/Tiles/RandomTile/RandomTile.cs
+++ b/Runtime/Tiles/RandomTile/RandomTile.cs
@@ -11,7 +11,7 @@ namespace UnityEngine.Tilemaps
     /// The Sprite displayed for the Tile is randomized based on its location and will be fixed for that particular location.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Random Tile", menuName = "Tiles/Random Tile")]
+    [CreateAssetMenu(fileName = "New Random Tile", menuName = "2D Extras/Tiles/Random Tile", order = 359)]
     public class RandomTile : Tile
     {
         /// <summary>

--- a/Runtime/Tiles/RuleOverrideTile/AdvancedRuleOverrideTile.cs
+++ b/Runtime/Tiles/RuleOverrideTile/AdvancedRuleOverrideTile.cs
@@ -9,7 +9,7 @@ namespace UnityEngine.Tilemaps
     /// </summary>
     [MovedFrom(true, "UnityEngine")]
     [Serializable]
-    [CreateAssetMenu(fileName = "New Advanced Rule Override Tile", menuName = "Tiles/Advanced Rule Override Tile")]
+    [CreateAssetMenu(fileName = "New Advanced Rule Override Tile", menuName = "2D Extras/Tiles/Advanced Rule Override Tile", order = 359)]
     public class AdvancedRuleOverrideTile : RuleOverrideTile
     {
 

--- a/Runtime/Tiles/RuleOverrideTile/RuleOverrideTile.cs
+++ b/Runtime/Tiles/RuleOverrideTile/RuleOverrideTile.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.Tilemaps
     /// </summary>
     [MovedFrom(true, "UnityEngine")]
     [Serializable]
-    [CreateAssetMenu(fileName = "New Rule Override Tile", menuName = "Tiles/Rule Override Tile")]
+    [CreateAssetMenu(fileName = "New Rule Override Tile", menuName = "2D Extras/Tiles/Rule Override Tile", order = 359)]
     public class RuleOverrideTile : TileBase
     {
 

--- a/Runtime/Tiles/RuleTile/RuleTile.cs
+++ b/Runtime/Tiles/RuleTile/RuleTile.cs
@@ -23,7 +23,7 @@ namespace UnityEngine
     /// Generic visual tile for creating different tilesets like terrain, pipeline, random or animated tiles.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Rule Tile", menuName = "Tiles/Rule Tile")]
+    [CreateAssetMenu(fileName = "New Rule Tile", menuName = "2D Extras/Tiles/Rule Tile", order = 359)]
     public class RuleTile : TileBase
     {
         /// <summary>

--- a/Runtime/Tiles/TerrainTile/TerrainTile.cs
+++ b/Runtime/Tiles/TerrainTile/TerrainTile.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.Tilemaps
     /// Terrain Tiles, similar to Pipeline Tiles, are tiles which take into consideration its orthogonal and diagonal neighboring tiles and displays a sprite depending on whether the neighboring tile is the same tile.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Terrain Tile", menuName = "Tiles/Terrain Tile")]
+    [CreateAssetMenu(fileName = "New Terrain Tile", menuName = "2D Extras/Tiles/Terrain Tile", order = 359)]
     public class TerrainTile : TileBase
     {
         /// <summary>

--- a/Runtime/Tiles/WeightedRandomTile/WeightedRandomTile.cs
+++ b/Runtime/Tiles/WeightedRandomTile/WeightedRandomTile.cs
@@ -27,7 +27,7 @@ namespace UnityEngine.Tilemaps
     /// The sprites can be weighted with a value to change its probability of appearing. The Sprite displayed for the Tile is randomized based on its location and will be fixed for that particular location.
     /// </summary>
     [Serializable]
-    [CreateAssetMenu(fileName = "New Weighted Random Tile", menuName = "Tiles/Weighted Random Tile")]
+    [CreateAssetMenu(fileName = "New Weighted Random Tile", menuName = "2D Extras/Tiles/Weighted Random Tile", order = 359)]
     public class WeightedRandomTile : Tile 
     {
         /// <summary>


### PR DESCRIPTION
Add option to create **Tiles** and **Brushes** assets grouped by **2D Extras** menu, after **Tile**.

![image](https://user-images.githubusercontent.com/7507819/80026745-07a08d00-84b9-11ea-92e3-5f60c996ef5a.png)

The order number was chosen based on [this guide](https://blog.redbluegames.com/guide-to-extending-unity-editors-menus-b2de47a746db).
