### PR TITLE
Use actual prefab rotation inside brush prefab

### DIFF
--- a/Editor/Brushes/PrefabBrushes/PrefabBrush/PrefabBrush.cs
+++ b/Editor/Brushes/PrefabBrushes/PrefabBrush/PrefabBrush.cs
@@ -46,7 +46,8 @@ namespace UnityEditor.Tilemaps
         {
             var objectsInCell = GetObjectsInCell(grid, brushTarget.transform, position);
             var existPrefabObjectInCell = objectsInCell.Any(objectInCell => PrefabUtility.GetCorrespondingObjectFromSource(objectInCell) == m_Prefab);
-
+            m_Rotation = Quaternion.Euler(m_Prefab.transform.eulerAngles);
+            
             if (!existPrefabObjectInCell)
             {
                 base.InstantiatePrefabInCell(grid, brushTarget, position, m_Prefab, m_Rotation);


### PR DESCRIPTION
If you paint a grid with a brush prefab it doesn't use prefab's rotation, instead it uses `m_Rotation` which is set to `default` and ignores the rotation.