### PR TITLE
Fix possible NullReferenceException in PrefabRandomBrush

### DIFF
--- a/Editor/Brushes/PrefabBrushes/PrefabRandomBrush/PrefabRandomBrush.cs
+++ b/Editor/Brushes/PrefabBrushes/PrefabRandomBrush/PrefabRandomBrush.cs
@@ -39,7 +39,7 @@ namespace UnityEditor.Tilemaps
         public override void Paint(GridLayout grid, GameObject brushTarget, Vector3Int position)
         {
             // Do not allow editing palettes
-            if (brushTarget.layer == 31 || brushTarget == null)
+            if (brushTarget == null || brushTarget.layer == 31)
             {
                 return;
             }


### PR DESCRIPTION
If brushTarget is allowed to be null we should first check for null and then check value of layer property.