### PR TITLE
2022.1/giserialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [3.1.3] - 2024-09-19
+### Fixed
+- [GameObjectBrush] Allow expansion of SceneRoot Grid foldout when clicking on label
+- [GridInformation] Fix exception when serializing GridInformation component if component is part of a Prefab
+
 ## [3.1.2] - 2023-08-21
 ### Fixed
 - [GameObjectBrush] Use cell offset to determine location of GameObject when painting and erasing

--- a/Editor/Brushes/GameObjectBrush/GameObjectBrush.cs
+++ b/Editor/Brushes/GameObjectBrush/GameObjectBrush.cs
@@ -778,7 +778,7 @@ namespace UnityEditor.Tilemaps
                 brush.SizeUpdated(true);
             }
 
-            hiddenGridFoldout = EditorGUILayout.Foldout(hiddenGridFoldout, "SceneRoot Grid");
+            hiddenGridFoldout = EditorGUILayout.Foldout(hiddenGridFoldout, "SceneRoot Grid", true);
             if (hiddenGridFoldout)
             {
                 EditorGUI.indentLevel++;

--- a/Runtime/GridInformation/GridInformation.cs
+++ b/Runtime/GridInformation/GridInformation.cs
@@ -106,10 +106,6 @@ namespace UnityEngine.Tilemaps
         /// </summary>
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
-            Grid grid = GetComponentInParent<Grid>();
-            if (grid == null)
-                return;
-
             m_PositionIntKeys.Clear();
             m_PositionIntValues.Clear();
             m_PositionStringKeys.Clear();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.2d.tilemap.extras",
     "displayName": "2D Tilemap Extras",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "unity": "2022.1",
     "description": "2D Tilemap Extras is a package that contains extra scripts for use with 2D Tilemap features in Unity. These include custom Tiles and Brushes for the Tilemap feature.\n\nThe following are included in the package:\nBrushes: GameObject Brush, Group Brush, Line Brush, Random Brush\nTiles: Animated Tile, Rule Tile, Rule Override Tile\nOther: Grid Information, Custom Rules for Rule Tile",
     "keywords": ["2d"],
@@ -13,7 +13,7 @@
 		"com.unity.modules.jsonserialize": "1.0.0"
     },
     "relatedPackages": {
-      "com.unity.2d.tilemap.extras.tests": "3.1.2"
+      "com.unity.2d.tilemap.extras.tests": "3.1.3"
     },
     "samples": [
         {


### PR DESCRIPTION
- Allow expansion of SceneRoot Grid foldout when clicking on label
- Fix exception when serializing GridInformation component if component is part of a Prefab